### PR TITLE
gspが使用するJDBCドライバへの依存を親POMから子POMに変更。

### DIFF
--- a/nablarch-archetype-parent/pom.xml
+++ b/nablarch-archetype-parent/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.nablarch.archetype</groupId>
   <artifactId>nablarch-archetype-parent</artifactId>
-  <version>5u12</version>
+  <version>5u13</version>
   <packaging>pom</packaging>
 
   <name>nablarch-archetype-parent</name>

--- a/nablarch-archetype-parent/pom.xml
+++ b/nablarch-archetype-parent/pom.xml
@@ -132,15 +132,6 @@
             <!-- 以下はimport-schemaゴール用のパラメータ -->
             <artifactId>${dba.testDataArtifactId}</artifactId>
           </configuration>
-          <dependencies>
-           <!-- プロジェクトで使用するDB製品にあわせたJDBCドライバに上書きする -->
-            <dependency>
-              <groupId>com.h2database</groupId>
-              <artifactId>h2</artifactId>
-              <version>1.3.176</version>
-              <scope>runtime</scope>
-            </dependency>
-          </dependencies>
         </plugin>
         <!--
           Mavenの各フェーズで自動実行するように設定するゴールについて、Eclipseのm2eプラグインがどのように扱うかを設定しておく。

--- a/nablarch-batch-ee/pom.xml
+++ b/nablarch-batch-ee/pom.xml
@@ -395,6 +395,19 @@
         </executions>
       </plugin>
       <!-- ================ここから任意で使用するツールの設定================ -->
+      <!-- エンティティクラス生成等を行うための設定 -->
+      <plugin>
+        <groupId>jp.co.tis.gsp</groupId>
+        <artifactId>gsp-dba-maven-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>1.3.176</version>
+            <scope>runtime</scope>
+          </dependency>
+        </dependencies>
+      </plugin>
       <!-- gsp-dba-maven-pluginで自動生成したソースをビルド時に使用するための設定 -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/nablarch-batch-ee/pom.xml
+++ b/nablarch-batch-ee/pom.xml
@@ -194,7 +194,7 @@
       <dependency>
         <groupId>com.nablarch.profile</groupId>
         <artifactId>nablarch-bom</artifactId>
-        <version>5u12</version>
+        <version>5u13</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/nablarch-batch-ee/pom.xml
+++ b/nablarch-batch-ee/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>com.nablarch.archetype</groupId>
     <artifactId>nablarch-archetype-parent</artifactId>
-    <version>5u12</version>
+    <version>5u13</version>
   </parent>
 
   <artifactId>nablarch-batch-ee</artifactId>
-  <version>5u12</version>
+  <version>5u13</version>
 
 
   <!-- DB接続設定とビルド設定 -->
@@ -92,6 +92,15 @@
                 </goals>
               </execution>
             </executions>
+            <dependencies>
+              <!-- プロジェクトで使用するDB製品にあわせたJDBCドライバに上書きする -->
+              <dependency>
+                <groupId>com.h2database</groupId>
+                <artifactId>h2</artifactId>
+                <version>1.3.176</version>
+                <scope>runtime</scope>
+              </dependency>
+            </dependencies>
           </plugin>
         </plugins>
       </build>
@@ -122,6 +131,15 @@
                 </goals>
               </execution>
             </executions>
+            <dependencies>
+              <!-- プロジェクトで使用するDB製品にあわせたJDBCドライバに上書きする -->
+              <dependency>
+                <groupId>com.h2database</groupId>
+                <artifactId>h2</artifactId>
+                <version>1.3.176</version>
+                <scope>runtime</scope>
+              </dependency>
+            </dependencies>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -395,19 +413,6 @@
         </executions>
       </plugin>
       <!-- ================ここから任意で使用するツールの設定================ -->
-      <!-- エンティティクラス生成等を行うための設定 -->
-      <plugin>
-        <groupId>jp.co.tis.gsp</groupId>
-        <artifactId>gsp-dba-maven-plugin</artifactId>
-        <dependencies>
-          <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <version>1.3.176</version>
-            <scope>runtime</scope>
-          </dependency>
-        </dependencies>
-      </plugin>
       <!-- gsp-dba-maven-pluginで自動生成したソースをビルド時に使用するための設定 -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/nablarch-batch/pom.xml
+++ b/nablarch-batch/pom.xml
@@ -192,7 +192,7 @@
       <dependency>
         <groupId>com.nablarch.profile</groupId>
         <artifactId>nablarch-bom</artifactId>
-        <version>5u12</version>
+        <version>5u13</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/nablarch-batch/pom.xml
+++ b/nablarch-batch/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>com.nablarch.archetype</groupId>
     <artifactId>nablarch-archetype-parent</artifactId>
-    <version>5u12</version>
+    <version>5u13</version>
   </parent>
 
   <artifactId>nablarch-batch</artifactId>
-  <version>5u12</version>
+  <version>5u13</version>
   <packaging>jar</packaging>
 
   <properties>
@@ -90,6 +90,15 @@
                 </goals>
               </execution>
             </executions>
+            <dependencies>
+              <!-- プロジェクトで使用するDB製品にあわせたJDBCドライバに上書きする -->
+              <dependency>
+                <groupId>com.h2database</groupId>
+                <artifactId>h2</artifactId>
+                <version>1.3.176</version>
+                <scope>runtime</scope>
+              </dependency>
+            </dependencies>
           </plugin>
         </plugins>
       </build>
@@ -120,6 +129,15 @@
                 </goals>
               </execution>
             </executions>
+            <dependencies>
+              <!-- プロジェクトで使用するDB製品にあわせたJDBCドライバに上書きする -->
+              <dependency>
+                <groupId>com.h2database</groupId>
+                <artifactId>h2</artifactId>
+                <version>1.3.176</version>
+                <scope>runtime</scope>
+              </dependency>
+            </dependencies>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -325,19 +343,6 @@
         </executions>
       </plugin>
       <!-- ================ここから任意で使用するツールの設定================ -->
-      <!-- エンティティクラス生成等を行うための設定 -->
-      <plugin>
-        <groupId>jp.co.tis.gsp</groupId>
-        <artifactId>gsp-dba-maven-plugin</artifactId>
-        <dependencies>
-          <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <version>1.3.176</version>
-            <scope>runtime</scope>
-          </dependency>
-        </dependencies>
-      </plugin>
       <!-- gsp-dba-maven-pluginで自動生成したソースをビルド時に使用するための設定 -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/nablarch-batch/pom.xml
+++ b/nablarch-batch/pom.xml
@@ -329,6 +329,14 @@
       <plugin>
         <groupId>jp.co.tis.gsp</groupId>
         <artifactId>gsp-dba-maven-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>1.3.176</version>
+            <scope>runtime</scope>
+          </dependency>
+        </dependencies>
       </plugin>
       <!-- gsp-dba-maven-pluginで自動生成したソースをビルド時に使用するための設定 -->
       <plugin>

--- a/nablarch-jaxrs/pom.xml
+++ b/nablarch-jaxrs/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>com.nablarch.archetype</groupId>
     <artifactId>nablarch-archetype-parent</artifactId>
-    <version>5u12</version>
+    <version>5u13</version>
   </parent>
 
   <artifactId>nablarch-jaxrs</artifactId>
-  <version>5u12</version>
+  <version>5u13</version>
   <packaging>war</packaging>
 
   <properties>
@@ -108,6 +108,15 @@
                 </goals>
               </execution>
             </executions>
+            <dependencies>
+              <!-- プロジェクトで使用するDB製品にあわせたJDBCドライバに上書きする -->
+              <dependency>
+                <groupId>com.h2database</groupId>
+                <artifactId>h2</artifactId>
+                <version>1.3.176</version>
+                <scope>runtime</scope>
+              </dependency>
+            </dependencies>
           </plugin>
         </plugins>
       </build>
@@ -138,6 +147,15 @@
                 </goals>
               </execution>
             </executions>
+            <dependencies>
+              <!-- プロジェクトで使用するDB製品にあわせたJDBCドライバに上書きする -->
+              <dependency>
+                <groupId>com.h2database</groupId>
+                <artifactId>h2</artifactId>
+                <version>1.3.176</version>
+                <scope>runtime</scope>
+              </dependency>
+            </dependencies>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -359,19 +377,6 @@
         </configuration>
       </plugin>
       <!-- ================ここから任意で使用するツールの設定================ -->
-      <!-- エンティティクラス生成等を行うための設定 -->
-      <plugin>
-        <groupId>jp.co.tis.gsp</groupId>
-        <artifactId>gsp-dba-maven-plugin</artifactId>
-        <dependencies>
-          <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <version>1.3.176</version>
-            <scope>runtime</scope>
-          </dependency>
-        </dependencies>
-      </plugin>      
       <!-- gsp-dba-maven-pluginで自動生成したソースをビルド時に使用するための設定 -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/nablarch-jaxrs/pom.xml
+++ b/nablarch-jaxrs/pom.xml
@@ -359,6 +359,19 @@
         </configuration>
       </plugin>
       <!-- ================ここから任意で使用するツールの設定================ -->
+      <!-- エンティティクラス生成等を行うための設定 -->
+      <plugin>
+        <groupId>jp.co.tis.gsp</groupId>
+        <artifactId>gsp-dba-maven-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>1.3.176</version>
+            <scope>runtime</scope>
+          </dependency>
+        </dependencies>
+      </plugin>      
       <!-- gsp-dba-maven-pluginで自動生成したソースをビルド時に使用するための設定 -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/nablarch-jaxrs/pom.xml
+++ b/nablarch-jaxrs/pom.xml
@@ -210,7 +210,7 @@
       <dependency>
         <groupId>com.nablarch.profile</groupId>
         <artifactId>nablarch-bom</artifactId>
-        <version>5u12</version>
+        <version>5u13</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/nablarch-web/pom.xml
+++ b/nablarch-web/pom.xml
@@ -217,7 +217,7 @@
       <dependency>
         <groupId>com.nablarch.profile</groupId>
         <artifactId>nablarch-bom</artifactId>
-        <version>5u12</version>
+        <version>5u13</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/nablarch-web/pom.xml
+++ b/nablarch-web/pom.xml
@@ -374,6 +374,19 @@
         </configuration>
       </plugin>
       <!-- ================ここから任意で使用するツールの設定================ -->
+      <!-- エンティティクラス生成等を行うための設定 -->
+      <plugin>
+        <groupId>jp.co.tis.gsp</groupId>
+        <artifactId>gsp-dba-maven-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>1.3.176</version>
+            <scope>runtime</scope>
+          </dependency>
+        </dependencies>
+      </plugin>
       <!-- gsp-dba-maven-pluginで自動生成したソースをビルド時に使用するための設定 -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/nablarch-web/pom.xml
+++ b/nablarch-web/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>com.nablarch.archetype</groupId>
     <artifactId>nablarch-archetype-parent</artifactId>
-    <version>5u12</version>
+    <version>5u13</version>
   </parent>
 
   <artifactId>nablarch-web</artifactId>
-  <version>5u12</version>
+  <version>5u13</version>
   <packaging>war</packaging>
 
   <properties>
@@ -115,6 +115,15 @@
                 </goals>
               </execution>
             </executions>
+            <dependencies>
+              <!-- プロジェクトで使用するDB製品にあわせたJDBCドライバに上書きする -->
+              <dependency>
+                <groupId>com.h2database</groupId>
+                <artifactId>h2</artifactId>
+                <version>1.3.176</version>
+                <scope>runtime</scope>
+              </dependency>
+            </dependencies>
           </plugin>
         </plugins>
       </build>
@@ -145,6 +154,15 @@
                 </goals>
               </execution>
             </executions>
+            <dependencies>
+              <!-- プロジェクトで使用するDB製品にあわせたJDBCドライバに上書きする -->
+              <dependency>
+                <groupId>com.h2database</groupId>
+                <artifactId>h2</artifactId>
+                <version>1.3.176</version>
+                <scope>runtime</scope>
+              </dependency>
+            </dependencies>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -374,19 +392,6 @@
         </configuration>
       </plugin>
       <!-- ================ここから任意で使用するツールの設定================ -->
-      <!-- エンティティクラス生成等を行うための設定 -->
-      <plugin>
-        <groupId>jp.co.tis.gsp</groupId>
-        <artifactId>gsp-dba-maven-plugin</artifactId>
-        <dependencies>
-          <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <version>1.3.176</version>
-            <scope>runtime</scope>
-          </dependency>
-        </dependencies>
-      </plugin>
       <!-- gsp-dba-maven-pluginで自動生成したソースをビルド時に使用するための設定 -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
gspが使用するJDBCドライバへの依存を親POMから子POMに変更。
BACKUPプロファイルと、gspプロファイルともに、JDBCドライバへの依存を使用できるようにbuildタグ内に依存関係を記述した。