### PR TITLE
HikariDataSourceに設定できる項目の追加と、廃棄処理の追加

### DIFF
--- a/nablarch-container-jaxrs/src/main/resources/data-source.xml
+++ b/nablarch-container-jaxrs/src/main/resources/data-source.xml
@@ -14,10 +14,15 @@
   <!-- TODO: プロジェクトで使用するDB製品にあわせた定義を設定してください。 -->
   <component name="dataSource"
              class="com.zaxxer.hikari.HikariDataSource" autowireType="None">
-    <property name="driverClassName" value="${nablarch.db.jdbcDriver}"/>
-    <property name="jdbcUrl"         value="${nablarch.db.url}"/>
-    <property name="username"        value="${nablarch.db.user}"/>
-    <property name="password"        value="${nablarch.db.password}"/>
-    <property name="maximumPoolSize" value="${nablarch.db.maxPoolSize}"/>
+    <property name="driverClassName"   value="${nablarch.db.jdbcDriver}"/>
+    <property name="jdbcUrl"           value="${nablarch.db.url}"/>
+    <property name="username"          value="${nablarch.db.user}"/>
+    <property name="password"          value="${nablarch.db.password}"/>
+    <property name="maximumPoolSize"   value="${nablarch.db.maxPoolSize}"/>
+    <property name="minimumIdle"       value="${nablarch.db.minimumIdle}"/>
+    <property name="connectionTimeout" value="${nablarch.db.connectionTimeout}"/>
+    <property name="idleTimeout"       value="${nablarch.db.idleTimeout}"/>
+    <property name="maxLifetime"       value="${nablarch.db.maxLifetime}"/>
+    <property name="validationTimeout" value="${nablarch.db.validationTimeout}"/>
   </component>
 </component-configuration>

--- a/nablarch-container-jaxrs/src/main/resources/env.config
+++ b/nablarch-container-jaxrs/src/main/resources/env.config
@@ -21,6 +21,21 @@ nablarch.db.schema=PUBLIC
 # 最大プールサイズ
 nablarch.db.maxPoolSize=5
 
+# 最小アイドル数
+nablarch.db.minimumIdle=5
+
+# プールから接続を取得するときのタイムアウト時間(ミリ秒)
+nablarch.db.connectionTimeout=30000
+
+# 接続のアイドルが維持される時間(ミリ秒)
+nablarch.db.idleTimeout=600000
+
+# プール内のコネクションの最大生存時間(ミリ秒)
+nablarch.db.maxLifetime=1800000
+
+# 接続が生きていることを確認するときのタイムアウト時間(ミリ秒)
+nablarch.db.validationTimeout=5000
+
 # コードの初期ロード設定
 # (本番ではレスポンスを重視し初期ロードを実施する。開発環境では起動速度を重視し初期ロードはしない。)
 nablarch.codeCache.loadOnStartUp=false

--- a/nablarch-container-jaxrs/src/main/resources/rest-component-configuration.xml
+++ b/nablarch-container-jaxrs/src/main/resources/rest-component-configuration.xml
@@ -87,4 +87,16 @@
       </list>
     </property>
   </component>
+
+  <!-- 廃棄が必要なコンポーネント -->
+  <component name="disposer"
+             class="nablarch.core.repository.disposal.BasicApplicationDisposer">
+    <property name="disposableList">
+      <list>
+        <component class="nablarch.core.repository.disposal.DisposableAdaptor">
+          <property name="target" ref="dataSource" />
+        </component>
+      </list>
+    </property>
+  </component>
 </component-configuration>

--- a/nablarch-container-web/src/main/resources/data-source.xml
+++ b/nablarch-container-web/src/main/resources/data-source.xml
@@ -14,11 +14,16 @@
   <!-- TODO: プロジェクトで使用するDB製品にあわせた定義を設定してください。 -->
   <component name="dataSource"
              class="com.zaxxer.hikari.HikariDataSource" autowireType="None">
-    <property name="driverClassName" value="${nablarch.db.jdbcDriver}"/>
-    <property name="jdbcUrl"         value="${nablarch.db.url}"/>
-    <property name="username"        value="${nablarch.db.user}"/>
-    <property name="password"        value="${nablarch.db.password}"/>
-    <property name="maximumPoolSize" value="${nablarch.db.maxPoolSize}"/>
+    <property name="driverClassName"   value="${nablarch.db.jdbcDriver}"/>
+    <property name="jdbcUrl"           value="${nablarch.db.url}"/>
+    <property name="username"          value="${nablarch.db.user}"/>
+    <property name="password"          value="${nablarch.db.password}"/>
+    <property name="maximumPoolSize"   value="${nablarch.db.maxPoolSize}"/>
+    <property name="minimumIdle"       value="${nablarch.db.minimumIdle}"/>
+    <property name="connectionTimeout" value="${nablarch.db.connectionTimeout}"/>
+    <property name="idleTimeout"       value="${nablarch.db.idleTimeout}"/>
+    <property name="maxLifetime"       value="${nablarch.db.maxLifetime}"/>
+    <property name="validationTimeout" value="${nablarch.db.validationTimeout}"/>
   </component>
 
 </component-configuration>

--- a/nablarch-container-web/src/main/resources/env.config
+++ b/nablarch-container-web/src/main/resources/env.config
@@ -25,6 +25,21 @@ nablarch.db.schema=PUBLIC
 # 最大プールサイズ
 nablarch.db.maxPoolSize=5
 
+# 最小アイドル数
+nablarch.db.minimumIdle=5
+
+# プールから接続を取得するときのタイムアウト時間(ミリ秒)
+nablarch.db.connectionTimeout=30000
+
+# 接続のアイドルが維持される時間(ミリ秒)
+nablarch.db.idleTimeout=600000
+
+# プール内のコネクションの最大生存時間(ミリ秒)
+nablarch.db.maxLifetime=1800000
+
+# 接続が生きていることを確認するときのタイムアウト時間(ミリ秒)
+nablarch.db.validationTimeout=5000
+
 # コードの初期ロード設定
 # (本番ではレスポンスを重視し true を設定して初期ロードを実施する。開発環境では起動速度を重視し false を設定して初期ロードはしない。)
 nablarch.codeCache.loadOnStartUp=false

--- a/nablarch-container-web/src/main/resources/web-component-configuration.xml
+++ b/nablarch-container-web/src/main/resources/web-component-configuration.xml
@@ -172,4 +172,16 @@
       </list>
     </property>
   </component>
+
+  <!-- 廃棄が必要なコンポーネント -->
+  <component name="disposer"
+             class="nablarch.core.repository.disposal.BasicApplicationDisposer">
+    <property name="disposableList">
+      <list>
+        <component class="nablarch.core.repository.disposal.DisposableAdaptor">
+          <property name="target" ref="dataSource" />
+        </component>
+      </list>
+    </property>
+  </component>
 </component-configuration>


### PR DESCRIPTION
- `HikariDataSource` に以下の項目を環境変数から設定できるように追加
  - `minimumIdle`
  - `connectionTimeout`
  - `idleTimeout`
  - `maxLifetime`
  - `validationTimeout`
- きっかけは、 `minimumIdle` のデフォルト値が `maxPoolSize` と同じため、起動直後に `maxPoolSize` 分のコネクションを確保してしまい、サービス開発のBlue/Greenデプロイ時にDBの最大接続数を超える問題が発生したため
- 設定で `minimumIdle` の値を調整できるようにした
- ただし、HikariCP自体は `maxPoolSize == minimumIdle` を推奨しており、また実際 `minimumIdle` の値をいくつにすべきかはプロジェクトごとに異なるため、アーキタイプでのデフォルト値は `maxPoolSize` と同じにしている
- そのほかの時間調整系の設定値は、すべて HikariCP のデフォルト値と同じ値を設定している
- ついでに、 `HikariDataSource` を廃棄処理の対象に設定する修正も加えている