### PR TITLE
SLF4Jアダプタによる大量ログ出力を抑制するためロガーの出力レベルを調整

### DIFF
--- a/nablarch-batch/src/test/resources/log.properties
+++ b/nablarch-batch/src/test/resources/log.properties
@@ -11,12 +11,17 @@ writer.nop.className=nablarch.test.core.log.NopLogWriter
 writer.verifier.className=nablarch.test.core.log.LogVerifier
 
 # 利用可能なロガー名順序
-availableLoggersNamesOrder=SQL,ROOT
+availableLoggersNamesOrder=SQL,NABLARCH,ROOT
 
-#全てのロガーを対象に、DEBUGレベル以上を出力する。
+#全てのロガーを対象に、INFOレベル以上を出力する。
 loggers.ROOT.nameRegex=.*
-loggers.ROOT.level=DEBUG
+loggers.ROOT.level=INFO
 loggers.ROOT.writerNames=stdout,verifier
+
+#Nablarchが生成するロガーを対象に、DEBUGレベル以上を出力する。
+loggers.NABLARCH.nameRegex=nablarch\\..*
+loggers.NABLARCH.level=DEBUG
+loggers.NABLARCH.writerNames=stdout
 
 #ロガー名に"SQL"を指定したロガーを対象に、TRACEレベル以上を出力する。
 loggers.SQL.nameRegex=SQL

--- a/nablarch-batch/src/test/resources/log.properties
+++ b/nablarch-batch/src/test/resources/log.properties
@@ -13,12 +13,12 @@ writer.verifier.className=nablarch.test.core.log.LogVerifier
 # 利用可能なロガー名順序
 availableLoggersNamesOrder=SQL,ROOT
 
-#全てのロガー取得を対象に、DEBUGレベル以上を標準出力に出力する。
+#全てのロガーを対象に、DEBUGレベル以上を出力する。
 loggers.ROOT.nameRegex=.*
 loggers.ROOT.level=DEBUG
 loggers.ROOT.writerNames=stdout,verifier
 
-#ロガー名に"SQL"を指定したロガー取得を対象に、DEBUGレベル以上を出力する。
+#ロガー名に"SQL"を指定したロガーを対象に、TRACEレベル以上を出力する。
 loggers.SQL.nameRegex=SQL
 loggers.SQL.level=TRACE
 loggers.SQL.writerNames=stdout

--- a/nablarch-container-jaxrs/src/test/resources/log.properties
+++ b/nablarch-container-jaxrs/src/test/resources/log.properties
@@ -11,20 +11,14 @@ writer.nop.className=nablarch.test.core.log.NopLogWriter
 writer.verifier.className=nablarch.test.core.log.LogVerifier
 
 # 利用可能なロガー名順序
+availableLoggersNamesOrder=SQL,ROOT
 
-availableLoggersNamesOrder=SQL,NABLARCH,ROOT
-
-#全てのロガー取得を対象に、INFOレベル以上を標準出力に出力する。
+#全てのロガー取得を対象に、DEBUGレベル以上を標準出力に出力する。
 loggers.ROOT.nameRegex=.*
-loggers.ROOT.level=INFO
+loggers.ROOT.level=DEBUG
 loggers.ROOT.writerNames=stdout,verifier
 
-#Nablarchが生成するロガー取得を対象に、DEBUGレベル以上を出力する。
-loggers.NABLARCH.nameRegex=nablarch\\..*
-loggers.NABLARCH.level=DEBUG
-loggers.NABLARCH.writerNames=stdout
-
-#ロガー名に"SQL"を指定したロガー取得を対象に、TRACEレベル以上を出力する。
+#ロガー名に"SQL"を指定したロガー取得を対象に、DEBUGレベル以上を出力する。
 loggers.SQL.nameRegex=SQL
 loggers.SQL.level=TRACE
 loggers.SQL.writerNames=stdout

--- a/nablarch-container-jaxrs/src/test/resources/log.properties
+++ b/nablarch-container-jaxrs/src/test/resources/log.properties
@@ -13,17 +13,17 @@ writer.verifier.className=nablarch.test.core.log.LogVerifier
 # 利用可能なロガー名順序
 availableLoggersNamesOrder=SQL,NABLARCH,ROOT
 
-#全てのロガー取得を対象に、INFOレベル以上を標準出力に出力する。
+#全てのロガーを対象に、INFOレベル以上を出力する。
 loggers.ROOT.nameRegex=.*
 loggers.ROOT.level=INFO
 loggers.ROOT.writerNames=stdout,verifier
 
-#Nablarchが生成するロガー取得を対象に、DEBUGレベル以上を出力する。
+#Nablarchが生成するロガーを対象に、DEBUGレベル以上を出力する。
 loggers.NABLARCH.nameRegex=nablarch\\..*
 loggers.NABLARCH.level=DEBUG
 loggers.NABLARCH.writerNames=stdout
 
-#ロガー名に"SQL"を指定したロガー取得を対象に、TRACEレベル以上を出力する。
+#ロガー名に"SQL"を指定したロガーを対象に、TRACEレベル以上を出力する。
 loggers.SQL.nameRegex=SQL
 loggers.SQL.level=TRACE
 loggers.SQL.writerNames=stdout

--- a/nablarch-container-jaxrs/src/test/resources/log.properties
+++ b/nablarch-container-jaxrs/src/test/resources/log.properties
@@ -11,14 +11,20 @@ writer.nop.className=nablarch.test.core.log.NopLogWriter
 writer.verifier.className=nablarch.test.core.log.LogVerifier
 
 # 利用可能なロガー名順序
-availableLoggersNamesOrder=SQL,ROOT
 
-#全てのロガー取得を対象に、DEBUGレベル以上を標準出力に出力する。
+availableLoggersNamesOrder=SQL,NABLARCH,ROOT
+
+#全てのロガー取得を対象に、INFOレベル以上を標準出力に出力する。
 loggers.ROOT.nameRegex=.*
-loggers.ROOT.level=DEBUG
+loggers.ROOT.level=INFO
 loggers.ROOT.writerNames=stdout,verifier
 
-#ロガー名に"SQL"を指定したロガー取得を対象に、DEBUGレベル以上を出力する。
+#Nablarchが生成するロガー取得を対象に、DEBUGレベル以上を出力する。
+loggers.NABLARCH.nameRegex=nablarch\\..*
+loggers.NABLARCH.level=DEBUG
+loggers.NABLARCH.writerNames=stdout
+
+#ロガー名に"SQL"を指定したロガー取得を対象に、TRACEレベル以上を出力する。
 loggers.SQL.nameRegex=SQL
 loggers.SQL.level=TRACE
 loggers.SQL.writerNames=stdout

--- a/nablarch-container-jaxrs/src/test/resources/log.properties
+++ b/nablarch-container-jaxrs/src/test/resources/log.properties
@@ -11,14 +11,19 @@ writer.nop.className=nablarch.test.core.log.NopLogWriter
 writer.verifier.className=nablarch.test.core.log.LogVerifier
 
 # 利用可能なロガー名順序
-availableLoggersNamesOrder=SQL,ROOT
+availableLoggersNamesOrder=SQL,NABLARCH,ROOT
 
-#全てのロガー取得を対象に、DEBUGレベル以上を標準出力に出力する。
+#全てのロガー取得を対象に、INFOレベル以上を標準出力に出力する。
 loggers.ROOT.nameRegex=.*
-loggers.ROOT.level=DEBUG
+loggers.ROOT.level=INFO
 loggers.ROOT.writerNames=stdout,verifier
 
-#ロガー名に"SQL"を指定したロガー取得を対象に、DEBUGレベル以上を出力する。
+#Nablarchが生成するロガー取得を対象に、DEBUGレベル以上を出力する。
+loggers.NABLARCH.nameRegex=nablarch\\..*
+loggers.NABLARCH.level=DEBUG
+loggers.NABLARCH.writerNames=stdout
+
+#ロガー名に"SQL"を指定したロガー取得を対象に、TRACEレベル以上を出力する。
 loggers.SQL.nameRegex=SQL
 loggers.SQL.level=TRACE
 loggers.SQL.writerNames=stdout

--- a/nablarch-container-web/src/test/resources/log.properties
+++ b/nablarch-container-web/src/test/resources/log.properties
@@ -13,17 +13,17 @@ writer.verifier.className=nablarch.test.core.log.LogVerifier
 # 利用可能なロガー名順序
 availableLoggersNamesOrder=SQL,NABLARCH,ROOT
 
-#全てのロガー取得を対象に、INFOレベル以上を標準出力に出力する。
+#全てのロガーを対象に、INFOレベル以上を出力する。
 loggers.ROOT.nameRegex=.*
 loggers.ROOT.level=INFO
 loggers.ROOT.writerNames=stdout,verifier
 
-#Nablarchが生成するロガー取得を対象に、DEBUGレベル以上を出力する。
+#Nablarchが生成するロガーを対象に、DEBUGレベル以上を出力する。
 loggers.NABLARCH.nameRegex=nablarch\\..*
 loggers.NABLARCH.level=DEBUG
 loggers.NABLARCH.writerNames=stdout
 
-#ロガー名に"SQL"を指定したロガー取得を対象に、TRACEレベル以上を出力する。
+#ロガー名に"SQL"を指定したロガーを対象に、TRACEレベル以上を出力する。
 loggers.SQL.nameRegex=SQL
 loggers.SQL.level=TRACE
 loggers.SQL.writerNames=stdout

--- a/nablarch-container-web/src/test/resources/log.properties
+++ b/nablarch-container-web/src/test/resources/log.properties
@@ -11,14 +11,19 @@ writer.nop.className=nablarch.test.core.log.NopLogWriter
 writer.verifier.className=nablarch.test.core.log.LogVerifier
 
 # 利用可能なロガー名順序
-availableLoggersNamesOrder=SQL,ROOT
+availableLoggersNamesOrder=SQL,NABLARCH,ROOT
 
-#全てのロガー取得を対象に、DEBUGレベル以上を標準出力に出力する。
+#全てのロガー取得を対象に、INFOレベル以上を標準出力に出力する。
 loggers.ROOT.nameRegex=.*
-loggers.ROOT.level=DEBUG
+loggers.ROOT.level=INFO
 loggers.ROOT.writerNames=stdout,verifier
 
-#ロガー名に"SQL"を指定したロガー取得を対象に、DEBUGレベル以上を出力する。
+#Nablarchが生成するロガー取得を対象に、DEBUGレベル以上を出力する。
+loggers.NABLARCH.nameRegex=nablarch\\..*
+loggers.NABLARCH.level=DEBUG
+loggers.NABLARCH.writerNames=stdout
+
+#ロガー名に"SQL"を指定したロガー取得を対象に、TRACEレベル以上を出力する。
 loggers.SQL.nameRegex=SQL
 loggers.SQL.level=TRACE
 loggers.SQL.writerNames=stdout

--- a/nablarch-jaxrs/src/test/resources/log.properties
+++ b/nablarch-jaxrs/src/test/resources/log.properties
@@ -11,12 +11,17 @@ writer.nop.className=nablarch.test.core.log.NopLogWriter
 writer.verifier.className=nablarch.test.core.log.LogVerifier
 
 # 利用可能なロガー名順序
-availableLoggersNamesOrder=SQL,ROOT
+availableLoggersNamesOrder=SQL,NABLARCH,ROOT
 
-#全てのロガーを対象に、DEBUGレベル以上を出力する。
+#全てのロガーを対象に、INFOレベル以上を出力する。
 loggers.ROOT.nameRegex=.*
-loggers.ROOT.level=DEBUG
+loggers.ROOT.level=INFO
 loggers.ROOT.writerNames=stdout,verifier
+
+#Nablarchが生成するロガーを対象に、DEBUGレベル以上を出力する。
+loggers.NABLARCH.nameRegex=nablarch\\..*
+loggers.NABLARCH.level=DEBUG
+loggers.NABLARCH.writerNames=stdout
 
 #ロガー名に"SQL"を指定したロガーを対象に、TRACEレベル以上を出力する。
 loggers.SQL.nameRegex=SQL

--- a/nablarch-jaxrs/src/test/resources/log.properties
+++ b/nablarch-jaxrs/src/test/resources/log.properties
@@ -13,12 +13,12 @@ writer.verifier.className=nablarch.test.core.log.LogVerifier
 # 利用可能なロガー名順序
 availableLoggersNamesOrder=SQL,ROOT
 
-#全てのロガー取得を対象に、DEBUGレベル以上を標準出力に出力する。
+#全てのロガーを対象に、DEBUGレベル以上を出力する。
 loggers.ROOT.nameRegex=.*
 loggers.ROOT.level=DEBUG
 loggers.ROOT.writerNames=stdout,verifier
 
-#ロガー名に"SQL"を指定したロガー取得を対象に、DEBUGレベル以上を出力する。
+#ロガー名に"SQL"を指定したロガーを対象に、TRACEレベル以上を出力する。
 loggers.SQL.nameRegex=SQL
 loggers.SQL.level=TRACE
 loggers.SQL.writerNames=stdout

--- a/nablarch-web/src/test/resources/log.properties
+++ b/nablarch-web/src/test/resources/log.properties
@@ -11,20 +11,14 @@ writer.nop.className=nablarch.test.core.log.NopLogWriter
 writer.verifier.className=nablarch.test.core.log.LogVerifier
 
 # 利用可能なロガー名順序
+availableLoggersNamesOrder=SQL,ROOT
 
-availableLoggersNamesOrder=SQL,NABLARCH,ROOT
-
-#全てのロガー取得を対象に、INFOレベル以上を標準出力に出力する。
+#全てのロガー取得を対象に、DEBUGレベル以上を標準出力に出力する。
 loggers.ROOT.nameRegex=.*
-loggers.ROOT.level=INFO
+loggers.ROOT.level=DEBUG
 loggers.ROOT.writerNames=stdout,verifier
 
-#Nablarchが生成するロガー取得を対象に、DEBUGレベル以上を出力する。
-loggers.NABLARCH.nameRegex=nablarch\\..*
-loggers.NABLARCH.level=DEBUG
-loggers.NABLARCH.writerNames=stdout
-
-#ロガー名に"SQL"を指定したロガー取得を対象に、TRACEレベル以上を出力する。
+#ロガー名に"SQL"を指定したロガー取得を対象に、DEBUGレベル以上を出力する。
 loggers.SQL.nameRegex=SQL
 loggers.SQL.level=TRACE
 loggers.SQL.writerNames=stdout

--- a/nablarch-web/src/test/resources/log.properties
+++ b/nablarch-web/src/test/resources/log.properties
@@ -11,14 +11,20 @@ writer.nop.className=nablarch.test.core.log.NopLogWriter
 writer.verifier.className=nablarch.test.core.log.LogVerifier
 
 # 利用可能なロガー名順序
-availableLoggersNamesOrder=SQL,ROOT
 
-#全てのロガー取得を対象に、DEBUGレベル以上を標準出力に出力する。
+availableLoggersNamesOrder=SQL,NABLARCH,ROOT
+
+#全てのロガー取得を対象に、INFOレベル以上を標準出力に出力する。
 loggers.ROOT.nameRegex=.*
-loggers.ROOT.level=DEBUG
+loggers.ROOT.level=INFO
 loggers.ROOT.writerNames=stdout,verifier
 
-#ロガー名に"SQL"を指定したロガー取得を対象に、DEBUGレベル以上を出力する。
+#Nablarchが生成するロガー取得を対象に、DEBUGレベル以上を出力する。
+loggers.NABLARCH.nameRegex=nablarch\\..*
+loggers.NABLARCH.level=DEBUG
+loggers.NABLARCH.writerNames=stdout
+
+#ロガー名に"SQL"を指定したロガー取得を対象に、TRACEレベル以上を出力する。
 loggers.SQL.nameRegex=SQL
 loggers.SQL.level=TRACE
 loggers.SQL.writerNames=stdout

--- a/nablarch-web/src/test/resources/log.properties
+++ b/nablarch-web/src/test/resources/log.properties
@@ -11,12 +11,17 @@ writer.nop.className=nablarch.test.core.log.NopLogWriter
 writer.verifier.className=nablarch.test.core.log.LogVerifier
 
 # 利用可能なロガー名順序
-availableLoggersNamesOrder=SQL,ROOT
+availableLoggersNamesOrder=SQL,NABLARCH,ROOT
 
-#全てのロガーを対象に、DEBUGレベル以上を出力する。
+#全てのロガーを対象に、INFOレベル以上を出力する。
 loggers.ROOT.nameRegex=.*
-loggers.ROOT.level=DEBUG
+loggers.ROOT.level=INFO
 loggers.ROOT.writerNames=stdout,verifier
+
+#Nablarchが生成するロガーを対象に、DEBUGレベル以上を出力する。
+loggers.NABLARCH.nameRegex=nablarch\\..*
+loggers.NABLARCH.level=DEBUG
+loggers.NABLARCH.writerNames=stdout
 
 #ロガー名に"SQL"を指定したロガーを対象に、TRACEレベル以上を出力する。
 loggers.SQL.nameRegex=SQL

--- a/nablarch-web/src/test/resources/log.properties
+++ b/nablarch-web/src/test/resources/log.properties
@@ -13,12 +13,12 @@ writer.verifier.className=nablarch.test.core.log.LogVerifier
 # 利用可能なロガー名順序
 availableLoggersNamesOrder=SQL,ROOT
 
-#全てのロガー取得を対象に、DEBUGレベル以上を標準出力に出力する。
+#全てのロガーを対象に、DEBUGレベル以上を出力する。
 loggers.ROOT.nameRegex=.*
 loggers.ROOT.level=DEBUG
 loggers.ROOT.writerNames=stdout,verifier
 
-#ロガー名に"SQL"を指定したロガー取得を対象に、DEBUGレベル以上を出力する。
+#ロガー名に"SQL"を指定したロガーを対象に、TRACEレベル以上を出力する。
 loggers.SQL.nameRegex=SQL
 loggers.SQL.level=TRACE
 loggers.SQL.writerNames=stdout


### PR DESCRIPTION
## 修正内容
- `nablarch-container-web`と`nablarch-container-jaxrs`のテスト用ログ出力設定を変更
- 全てのロガーに対する出力レベルを`DEBUG`からINFOに変更
- Nablarchの出力するロガーを新たに定義し`DEBUG`レベルとする

## 修正の背景
- SLF4Jアダプタを追加したことにより今まで出力されなかった大量のログが出力され、ビルドに長時間かかるようになった
- 大量ログを出力するのは`Jetty9`が依存するライブラリのためデフォルトで`Jetty9`を利用するコンテナ用アーキタイプのログ出力を抑制した

## その他
- SQLをTRACEレベルで出力しているのにコメントはDEBUGとなっていたのであわせて修正
- 「ロガー`取得`を対象として」というコメントに違和感があったので修正
- 設定変更していないものもコメントを横並び修正