### PR TITLE
環境依存値の不足を追加

### DIFF
--- a/nablarch-container-jaxrs/src/main/resources/common.properties
+++ b/nablarch-container-jaxrs/src/main/resources/common.properties
@@ -34,6 +34,9 @@ nablarch.languageAttribute.defaultLanguage=ja
 nablarch.languageAttribute.supportedLanguages=ja
 nablarch.languageAttribute.cookieMaxAge=600000
 
+# スレッドコンテキストに格納されるデフォルトのタイムゾーン
+nablarch.timeZoneAttribute.defaultTimeZone=${nablarch.timeZoneAttribute.defaultTimeZone}
+
 # 未ログイン時、ログに出力するユーザID
 # TODO: ログイン時、ログにユーザIDを出力するためには別途実装を行うこと
 nablarch.userIdAttribute.anonymousId=guest

--- a/nablarch-container-jaxrs/src/main/resources/common.properties
+++ b/nablarch-container-jaxrs/src/main/resources/common.properties
@@ -35,7 +35,7 @@ nablarch.languageAttribute.supportedLanguages=ja
 nablarch.languageAttribute.cookieMaxAge=600000
 
 # スレッドコンテキストに格納されるデフォルトのタイムゾーン
-nablarch.timeZoneAttribute.defaultTimeZone=${nablarch.timeZoneAttribute.defaultTimeZone}
+nablarch.timeZoneAttribute.defaultTimeZone=Asia/Tokyo
 
 # 未ログイン時、ログに出力するユーザID
 # TODO: ログイン時、ログにユーザIDを出力するためには別途実装を行うこと

--- a/nablarch-container-jaxrs/src/main/resources/rest-component-configuration.xml
+++ b/nablarch-container-jaxrs/src/main/resources/rest-component-configuration.xml
@@ -24,7 +24,7 @@
   <config-file file="env.properties"/>
 
   <!-- データベース設定 -->
-  <import file="nablarch/webui/db-for-webui.xml"/>
+  <import file="nablarch/core/db-base.xml" />
   <import file="data-source.xml" />
 
   <!-- スレッドコンテキストハンドラ -->

--- a/nablarch-container-web/src/main/resources/common.properties
+++ b/nablarch-container-web/src/main/resources/common.properties
@@ -79,7 +79,7 @@ nablarch.languageAttribute.supportedLanguages=ja
 nablarch.languageAttribute.cookieMaxAge=600000
 
 # スレッドコンテキストに格納されるデフォルトのタイムゾーン
-nablarch.timeZoneAttribute.defaultTimeZone=${nablarch.timeZoneAttribute.defaultTimeZone}
+nablarch.timeZoneAttribute.defaultTimeZone=Asia/Tokyo
 
 # 未ログイン時、ログに出力するユーザID
 # TODO: ログイン時、ログにユーザIDを出力するためには別途実装を行うこと

--- a/nablarch-container-web/src/main/resources/common.properties
+++ b/nablarch-container-web/src/main/resources/common.properties
@@ -78,6 +78,9 @@ nablarch.languageAttribute.defaultLanguage=ja
 nablarch.languageAttribute.supportedLanguages=ja
 nablarch.languageAttribute.cookieMaxAge=600000
 
+# スレッドコンテキストに格納されるデフォルトのタイムゾーン
+nablarch.timeZoneAttribute.defaultTimeZone=${nablarch.timeZoneAttribute.defaultTimeZone}
+
 # 未ログイン時、ログに出力するユーザID
 # TODO: ログイン時、ログにユーザIDを出力するためには別途実装を行うこと
 nablarch.userIdAttribute.anonymousId=guest

--- a/nablarch-container-web/src/main/resources/web-component-configuration.xml
+++ b/nablarch-container-web/src/main/resources/web-component-configuration.xml
@@ -28,7 +28,7 @@
 
   <!-- web固有設定の読み込み -->
   <!-- データベース設定 -->
-  <import file="nablarch/webui/db-for-webui.xml"/>
+  <import file="nablarch/core/db-base.xml" />
   <import file="data-source.xml" />
 
   <!-- エラーページ設定 -->

--- a/nablarch-jaxrs/src/env/dev/resources/env.properties
+++ b/nablarch-jaxrs/src/env/dev/resources/env.properties
@@ -28,3 +28,11 @@ nablarch.db.maxPoolSize=5
 # コードの初期ロード設定
 # (本番ではレスポンスを重視し初期ロードを実施する。開発環境では起動速度を重視し初期ロードはしない。)
 nablarch.codeCache.loadOnStartUp=false
+
+# JNDIでDataSourceを取得する際のリソース名
+# 開発環境ではDataSourceを直接使用するためこの値は使用されないが
+# 本番環境で使用するJNDI用コネクションファクトリを構築するために必要になるので削除しないこと。
+# Nablarchではコンポーネントの上書きをする場合でも一度JNDI用コネクションファクトリを
+# オブジェクトとして作成している。この時に環境依存値が取得できないとエラーとなってしまうため
+# ルックアップには使用されない以下の環境依存値をenv.propertiesに記載しておく必要がある。
+nablarch.connectionFactory.jndiResourceName=not_used

--- a/nablarch-jaxrs/src/main/resources/common.properties
+++ b/nablarch-jaxrs/src/main/resources/common.properties
@@ -34,6 +34,9 @@ nablarch.languageAttribute.defaultLanguage=ja
 nablarch.languageAttribute.supportedLanguages=ja
 nablarch.languageAttribute.cookieMaxAge=600000
 
+# スレッドコンテキストに格納されるデフォルトのタイムゾーン
+nablarch.timeZoneAttribute.defaultTimeZone=${nablarch.timeZoneAttribute.defaultTimeZone}
+
 # 未ログイン時、ログに出力するユーザID
 # TODO: ログイン時、ログにユーザIDを出力するためには別途実装を行うこと
 nablarch.userIdAttribute.anonymousId=guest

--- a/nablarch-jaxrs/src/main/resources/common.properties
+++ b/nablarch-jaxrs/src/main/resources/common.properties
@@ -35,7 +35,7 @@ nablarch.languageAttribute.supportedLanguages=ja
 nablarch.languageAttribute.cookieMaxAge=600000
 
 # スレッドコンテキストに格納されるデフォルトのタイムゾーン
-nablarch.timeZoneAttribute.defaultTimeZone=${nablarch.timeZoneAttribute.defaultTimeZone}
+nablarch.timeZoneAttribute.defaultTimeZone=Asia/Tokyo
 
 # 未ログイン時、ログに出力するユーザID
 # TODO: ログイン時、ログにユーザIDを出力するためには別途実装を行うこと

--- a/nablarch-web/src/env/dev/resources/env.properties
+++ b/nablarch-web/src/env/dev/resources/env.properties
@@ -1,7 +1,6 @@
 ##
 ## 開発環境用設定ファイル
 ##
-
 # JDBC接続ドライバクラス(DataSourceを直接使用する際の項目)
 # (TODO: 開発環境で使用するDBに合わせて変更する。)
 nablarch.db.jdbcDriver=org.h2.Driver
@@ -54,3 +53,11 @@ nablarch.uploadSettings.autoCleaning=false
 # アップロードファイル一時ディレクトリ
 # (TODO: PJのファイルパスに変更する)
 nablarch.filePathSetting.basePathSettings.uploadFileTmpDir=file:./work/tmp
+
+# JNDIでDataSourceを取得する際のリソース名
+# 開発環境ではDataSourceを直接使用するためこの値は使用されないが
+# 本番環境で使用するJNDI用コネクションファクトリを構築するために必要になるので削除しないこと。
+# Nablarchではコンポーネントの上書きをする場合でも一度JNDI用コネクションファクトリを
+# オブジェクトとして作成している。この時に環境依存値が取得できないとエラーとなってしまうため
+# ルックアップには使用されない以下の環境依存値をenv.propertiesに記載しておく必要がある。
+nablarch.connectionFactory.jndiResourceName=not_used

--- a/nablarch-web/src/main/resources/common.properties
+++ b/nablarch-web/src/main/resources/common.properties
@@ -79,7 +79,7 @@ nablarch.languageAttribute.supportedLanguages=ja
 nablarch.languageAttribute.cookieMaxAge=600000
 
 # スレッドコンテキストに格納されるデフォルトのタイムゾーン
-nablarch.timeZoneAttribute.defaultTimeZone=${nablarch.timeZoneAttribute.defaultTimeZone}
+nablarch.timeZoneAttribute.defaultTimeZone=Asia/Tokyo
 
 # 未ログイン時、ログに出力するユーザID
 # TODO: ログイン時、ログにユーザIDを出力するためには別途実装を行うこと

--- a/nablarch-web/src/main/resources/common.properties
+++ b/nablarch-web/src/main/resources/common.properties
@@ -78,6 +78,9 @@ nablarch.languageAttribute.defaultLanguage=ja
 nablarch.languageAttribute.supportedLanguages=ja
 nablarch.languageAttribute.cookieMaxAge=600000
 
+# スレッドコンテキストに格納されるデフォルトのタイムゾーン
+nablarch.timeZoneAttribute.defaultTimeZone=${nablarch.timeZoneAttribute.defaultTimeZone}
+
 # 未ログイン時、ログに出力するユーザID
 # TODO: ログイン時、ログにユーザIDを出力するためには別途実装を行うこと
 nablarch.userIdAttribute.anonymousId=guest


### PR DESCRIPTION
# 背景

https://github.com/nablarch/nablarch-core-repository/pull/24
https://github.com/nablarch/nablarch-core-repository/pull/25
の変更により環境依存値が設定されていない場合例外が送出されるようになった。

アーキタイプからブランクプロジェクトを生成して疎通確認を行ったところ以下の問題があった。
1. WebとWebサービス（コンテナ用アーキタイプも含む）のプロジェクトでタイムゾーンの設定がなくエラーとなった
2. WebとWebサービスのプロジェクトで本番環境はJNDI用のコネクションファクトリ設定、開発環境ではデータソース直接使用の設定となっており、本番用設定をオーバーライドする形でコンポーネント定義されていた。開発環境ではJNDI用の環境依存値が設定されていなかった。オーバーライドする場合でも本番用設定のコンポーネントが読み込まれた時点で環境依存値を取得しにいくためJNDI用の環境依存値が取得できずエラーとなってローカル実行できなかった。
3. コンテナ用のWebとWebサービスで、データソースを直接使用するが、DBのベースとなる設定を読み込んだ際にJNDI用のコネクションファクトリ設定も合わせて読み込む定義となっていた。JNDIはどの環境でも使用されないがコンポーネント定義を読み込んでいるために環境依存値が取得できずエラーとなった。

# 対応方針

1. 対応としてはデフォルト設定のコンポーネント定義からプレースホルダとして定義しているプロパティを削除し、タイムゾーンを変更する場合はプロジェクトでコンポーネント定義を差し替えてもらう方法と、デフォルト設定のコンポーネント定義は変更せず、環境依存値をプロジェクトに持つ方法がある。タイムゾーンの設定をプレースホルダとして定義しておいた方がプロジェクトで変更が容易であり利便性があると判断し、環境依存値をプロジェクトに持つこととした。
2. 開発環境でJNDI用の環境依存値にダミーの値を設定しコメントに経緯を記載した
3. JNDI用のコンポーネント定義が読み込まれないようにimportする定義ファイルを変更した

# 各アーキタイプの変更

- nablarch-container-jaxrs
1. タイムゾーンの設定が不足していたため追加。
2. 本番環境でもJNDIを使用せず直接データソースを使用する想定のため`nablarch/webui/db-for-webui.xml`ではなく`nablarch/core/db-base.xml`をimportするように変更した。

- nablarch-container-web
1. タイムゾーンの設定が不足していたため追加。
2. 本番環境でもJNDIを使用せず直接データソースを使用する想定のため`nablarch/webui/db-for-webui.xml`ではなく`nablarch/core/db-base.xml`をimportするように変更した。

- nablarch-web
1. タイムゾーンの設定が不足していたため追加。
2. 開発環境で使用しないJNDIでDataSourceを取得する際のリソース名について、コメントに注意書きを追記した上でダミーの値を記載した。

- nablarch-jaxrs
1. タイムゾーンの設定が不足していたため追加。
2. 開発環境で使用しないJNDIでDataSourceを取得する際のリソース名について、コメントに注意書きを追記した上でダミーの値を記載した。
