### PR TITLE
jetty11 対応が完了するまで bom から削除した jetty のバージョン指定を明記しておく修正

### DIFF
--- a/nablarch-container-jaxrs/pom.xml
+++ b/nablarch-container-jaxrs/pom.xml
@@ -218,6 +218,11 @@
     <dependency>
       <groupId>com.nablarch.framework</groupId>
       <artifactId>nablarch-testing-jetty9</artifactId>
+      <!--
+        最終的には jetty11 に対応したアーティファクトに切り替えてバージョンは bom で管理する。
+        ここでバージョンを明記しているのは CI を通すための一次的な処置。
+       -->
+      <version>5-NEXT-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
 

--- a/nablarch-container-web/pom.xml
+++ b/nablarch-container-web/pom.xml
@@ -238,6 +238,11 @@
     <dependency>
       <groupId>com.nablarch.framework</groupId>
       <artifactId>nablarch-testing-jetty9</artifactId>
+      <!--
+        最終的には jetty11 に対応したアーティファクトに切り替えてバージョンは bom で管理する。
+        ここでバージョンを明記しているのは CI を通すための一次的な処置。
+       -->
+      <version>5-NEXT-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
 

--- a/nablarch-jaxrs/pom.xml
+++ b/nablarch-jaxrs/pom.xml
@@ -239,6 +239,11 @@
     <dependency>
       <groupId>com.nablarch.framework</groupId>
       <artifactId>nablarch-testing-jetty6</artifactId>
+      <!--
+        最終的には jetty11 に対応したアーティファクトに切り替えてバージョンは bom で管理する。
+        ここでバージョンを明記しているのは CI を通すための一次的な処置。
+       -->
+      <version>5-NEXT-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
 

--- a/nablarch-web/pom.xml
+++ b/nablarch-web/pom.xml
@@ -259,6 +259,11 @@
     <dependency>
       <groupId>com.nablarch.framework</groupId>
       <artifactId>nablarch-testing-jetty6</artifactId>
+      <!--
+        最終的には jetty11 に対応したアーティファクトに切り替えてバージョンは bom で管理する。
+        ここでバージョンを明記しているのは CI を通すための一次的な処置。
+       -->
+      <version>5-NEXT-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
bom から jetty6, jetty9 の記述を削除したことで、 jetty6 の version を省略していることが pom 定義上アウトになってエラーが発生するようになっている。
最終的には jetty11 に対応したプラグインに差し替えることになるので、それまでは version を明記しておく。