### PR TITLE
Java 17 対応

### DIFF
--- a/nablarch-archetype-parent/pom.xml
+++ b/nablarch-archetype-parent/pom.xml
@@ -55,7 +55,7 @@
     <version.plugins.compiler>3.2</version.plugins.compiler>
     <version.plugins.surefire>2.22.2</version.plugins.surefire>
     <version.plugins.antrun>1.7</version.plugins.antrun>
-    <version.plugins.war>2.5</version.plugins.war>
+    <version.plugins.war>3.3.2</version.plugins.war>
     <version.plugins.assembly>2.5.1</version.plugins.assembly>
     <version.plugins.clean>2.5</version.plugins.clean>
     <version.plugins.deploy>2.8.2</version.plugins.deploy>

--- a/nablarch-archetype-parent/pom.xml
+++ b/nablarch-archetype-parent/pom.xml
@@ -66,7 +66,7 @@
     <version.plugins.javadoc>2.10.1</version.plugins.javadoc>
     <version.plugins.resources>2.7</version.plugins.resources>
     <version.plugins.source>2.4</version.plugins.source>
-    <version.plugins.jacoco>0.8.3</version.plugins.jacoco>
+    <version.plugins.jacoco>0.8.7</version.plugins.jacoco>
     <version.plugins.build-helper-maven>1.9.1</version.plugins.build-helper-maven>
     <version.plugins.jib>2.1.0</version.plugins.jib>
 


### PR DESCRIPTION
Java 17 でビルドした際、以下２つのエラーが発生したため対応。

- jacoco が Java 17 に対応しておらずエラー
- `mvn package` で war を生成するときにエラー

jacoco については、 0.8.7 で試験的ではあるが Java 17 に対応しており、 jacoco プラグインのバージョンを 0.8.7 に上げることでエラーがでなくなることを確認した。
0.8.7 指定時に、 Java 8, 11 でもエラーにならないことは確認済み。

https://www.jacoco.org/jacoco/trunk/doc/changes.html

> Release 0.8.7 (2021/05/04)
> Experimental support for Java 17 class files (GitHub #1132).

war のエラーについては、 maven-war-plugin のバージョンを上げることで発生しなくなった。
issue は見つけられなかったがバージョンを上げればなおる・なおったという報告はいくつかあった。

- https://stdworkflow.com/712/solve-the-error-when-maven-project-is-packaged-error-injecting-constructor
- https://stackoverflow.com/questions/67168999/maven-error-cannot-access-defaults-field-of-properties

# 参考
## jacoco エラー
```log
Caused by: java.lang.IllegalArgumentException: Unsupported class file major version 61
        at org.jacoco.agent.rt.internal_f3994fa.asm.ClassReader.<init>(ClassReader.java:196)
```

## maven-war-plugin エラー
```log
Caused by: java.lang.ExceptionInInitializerError: Cannot access defaults field of Properties
    at com.thoughtworks.xstream.converters.collections.PropertiesConverter.<clinit> (PropertiesConverter.java:46)
    at com.thoughtworks.xstream.XStream.setupConverters (XStream.java:647)
    at com.thoughtworks.xstream.XStream.<init> (XStream.java:445)
    at com.thoughtworks.xstream.XStream.<init> (XStream.java:385)
    at com.thoughtworks.xstream.XStream.<init> (XStream.java:342)
    at org.apache.maven.plugin.war.util.WebappStructureSerializer.<clinit> (WebappStructureSerializer.java:47)
```