### PR TITLE
ETLでは主キー情報取得時の例外情報ログを出力抑制するよう変更

### DIFF
--- a/nablarch-batch-ee/src/env/dev/resources/env.properties
+++ b/nablarch-batch-ee/src/env/dev/resources/env.properties
@@ -44,3 +44,7 @@ nablarch.etl.inputFileBasePath=testdata/input
 # ETLの出力ファイルの格納ディレクトリ
 # TODO: PJのファイルパスに変更する
 nablarch.etl.outputFileBasePath=testdata/output
+
+# ETLではワークテーブル、エラーテーブルと本テーブルで主キー定義が異なるため
+# 主キー取得時に例外が発生する。例外発生は想定通りの動作のため例外のログ出力を抑制する。
+nablarch.entityMeta.hideCauseExceptionLog=true

--- a/nablarch-batch-ee/src/env/prod/resources/env.properties
+++ b/nablarch-batch-ee/src/env/prod/resources/env.properties
@@ -36,3 +36,7 @@ nablarch.etl.inputFileBasePath=/var/nablarch/testdata/input
 # ETLの出力ファイルの格納ディレクトリ
 # TODO: PJのファイルパスに変更する
 nablarch.etl.outputFileBasePath=/var/nablarch/testdata/output
+
+# ETLではワークテーブル、エラーテーブルと本テーブルで主キー定義が異なるため
+# 主キー取得時に例外が発生する。例外発生は想定通りの動作のため例外のログ出力を抑制する。
+nablarch.entityMeta.hideCauseExceptionLog=true


### PR DESCRIPTION
ETLではワークテーブル、エラーテーブルでは行番号、本テーブルではIDというように主キー情報が異なることがある。しかしワークテーブル、エラーテーブルにデータ登録する際のエンティティを本テーブルのものと同じにしているため主キー情報取得時に例外が発生する。
例外は発生するがETLの動きとしては想定内であり、主キー情報を修正する必要はない。
無駄にログが出力されることを防ぐため、主キー取得時の例外ログを抑制する。