### PR TITLE
CSRFトークン検証ハンドラを追加

### DIFF
--- a/nablarch-container-web/src/main/resources/web-component-configuration.xml
+++ b/nablarch-container-web/src/main/resources/web-component-configuration.xml
@@ -111,6 +111,10 @@
     </property>
   </component>
 
+  <!-- CSRF対策 -->
+  <component name="csrfTokenVerificationHandler"
+             class="nablarch.fw.web.handler.CsrfTokenVerificationHandler" />
+
   <!-- ハンドラキュー構成 -->
   <component name="webFrontController"
              class="nablarch.fw.web.servlet.WebFrontController">
@@ -144,6 +148,8 @@
         <component-ref name="httpErrorHandler" />
 
         <component-ref name="nablarchTagHandler"/>
+
+        <component-ref name="csrfTokenVerificationHandler" />
 
         <component-ref name="dbConnectionManagementHandler"/>
 

--- a/nablarch-container-web/src/test/resources/override_test.xml
+++ b/nablarch-container-web/src/test/resources/override_test.xml
@@ -8,4 +8,7 @@
   <import file="nablarch/core/date_test.xml"/>
   <import file="nablarch/core/fixed-length-convertor-setting_test.xml"/>
 
+  <!-- CSRF対策の無効化 -->
+  <component name="csrfTokenVerificationHandler" class="nablarch.test.NopHandler" />
+
 </component-configuration>

--- a/nablarch-web/src/env/dev/resources/handler_dev.xml
+++ b/nablarch-web/src/env/dev/resources/handler_dev.xml
@@ -46,6 +46,8 @@
 
         <component-ref name="nablarchTagHandler"/>
 
+        <component-ref name="csrfTokenVerificationHandler" />
+
         <component-ref name="dbConnectionManagementHandler"/>
 
         <component-ref name="transactionManagementHandler"/>

--- a/nablarch-web/src/main/resources/web-component-configuration.xml
+++ b/nablarch-web/src/main/resources/web-component-configuration.xml
@@ -101,6 +101,9 @@
   <!-- TODO:使用するDBに合わせてダイアレクトを設定すること -->
   <component name="dialect" class="nablarch.core.db.dialect.H2Dialect" />
 
+  <!-- CSRF対策 -->
+  <component name="csrfTokenVerificationHandler"
+             class="nablarch.fw.web.handler.CsrfTokenVerificationHandler" />
 
   <!-- ハンドラキュー構成 -->
   <component name="webFrontController"
@@ -133,6 +136,8 @@
         <component-ref name="httpErrorHandler" />
 
         <component-ref name="nablarchTagHandler"/>
+
+        <component-ref name="csrfTokenVerificationHandler" />
 
         <component-ref name="dbConnectionManagementHandler"/>
 

--- a/nablarch-web/src/test/resources/override_test.xml
+++ b/nablarch-web/src/test/resources/override_test.xml
@@ -8,4 +8,7 @@
   <import file="nablarch/core/date_test.xml"/>
   <import file="nablarch/core/fixed-length-convertor-setting_test.xml"/>
 
+  <!-- CSRF対策の無効化 -->
+  <component name="csrfTokenVerificationHandler" class="nablarch.test.NopHandler" />
+
 </component-configuration>


### PR DESCRIPTION
Webの方は、開発環境ではハンドラキューを`src/env/dev/resources/handler_dev.xml`で書き換えるようにしています。
このハンドラキューでCSRFトークン検証ハンドラをコメントアウトすることも考えましたが、ホットデプロイハンドラを使わないプロジェクトが`handler_dev.xml`を読み込まないようにした場合にはまる可能性があるので、`handler_dev.xml`にもCSRFトークン検証ハンドラを追加し、コンポーネント定義で無効化するようにしました。