### PR TITLE
セキュリティアラート対応（ch.qos.logback:logback-classic to 1.2.13）

### DIFF
--- a/nablarch-batch-ee/pom.xml
+++ b/nablarch-batch-ee/pom.xml
@@ -376,7 +376,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.4</version>
+      <version>1.2.13</version>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
https://github.com/nablarch/nablarch-single-module-archetype/pull/142
の対応