### PR TITLE
v6で静的解析ツールのエラーが発生するためnablarch-toolboxのバージョンを修正

### DIFF
--- a/nablarch-archetype-parent/pom.xml
+++ b/nablarch-archetype-parent/pom.xml
@@ -72,6 +72,7 @@
     <version.plugins.spotbugs>4.8.3.0</version.plugins.spotbugs>
     <version.plugins.unpublished.api.checker>5-NEXT-SNAPSHOT</version.plugins.unpublished.api.checker>
     <version.plugins.findsecbugs>1.11.0</version.plugins.findsecbugs>
+    <version.nablarch.toolbox>6-NEXT-SNAPSHOT</version.nablarch.toolbox>
 
     <!-- toolsディレクトリへのパス -->
     <nablarch.tools.dir>${project.basedir}/tools</nablarch.tools.dir>
@@ -255,7 +256,7 @@
             <dependency>
               <groupId>com.nablarch.tool</groupId>
               <artifactId>nablarch-toolbox</artifactId>
-              <version>1.0.2</version>
+              <version>${version.nablarch.toolbox}</version>
               <exclusions>
                 <exclusion>
                   <groupId>ant</groupId>


### PR DESCRIPTION
JakartaServerPages静的解析ツールを実行すると、以下のエラーが発生していた。

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-antrun-plugin:1.7:run (verify-jsp) on project nablarch-web: Execution verify-jsp of goal org.apache.maven.plugins:maven-antrun-plugin:1.7:run failed: Plugin org.apache.maven.plugins:maven-antrun-plugin:1.7 or one of its dependencies could not be resolved:
```

maven-antrun-pluginの依存関係にnablarch-toolboxを指定しているが、古いバージョンを固定で指定していたため、Nablarch 6に対応するバージョンに修正した。