### PR TITLE
SpotBugsとFindSecurityBugsをバージョンアップ

### DIFF
--- a/nablarch-archetype-parent/pom.xml
+++ b/nablarch-archetype-parent/pom.xml
@@ -69,9 +69,10 @@
     <version.plugins.jacoco>0.8.11</version.plugins.jacoco>
     <version.plugins.build-helper-maven>1.9.1</version.plugins.build-helper-maven>
     <version.plugins.jib>3.3.1</version.plugins.jib>
-    <version.plugins.spotbugs>4.8.3.0</version.plugins.spotbugs>
+    <version.plugins.spotbugs>4.8.6.2</version.plugins.spotbugs>
+    <spotbugs.version>4.8.6</spotbugs.version>
     <version.plugins.unpublished.api.checker>5-NEXT-SNAPSHOT</version.plugins.unpublished.api.checker>
-    <version.plugins.findsecbugs>1.11.0</version.plugins.findsecbugs>
+    <version.plugins.findsecbugs>1.13.0</version.plugins.findsecbugs>
     <version.nablarch.toolbox>6-NEXT-SNAPSHOT</version.nablarch.toolbox>
 
     <!-- toolsディレクトリへのパス -->
@@ -108,8 +109,6 @@
     <jib.to.image>${project.artifactId}</jib.to.image>
     <!-- 生成するタグ -->
     <jib.to.tags>latest,${project.version}</jib.to.tags>
-    
-    <spotbugs.version>4.8.3</spotbugs.version>
   </properties>
 
 


### PR DESCRIPTION
v6向けのブランクプロジェクトで設定されているFindSecurityBugsのバージョンが古く、Java 17をサポートしている [1.12.0](https://github.com/find-sec-bugs/find-sec-bugs/releases/tag/version-1.12.0) 以上にバージョンアップする必要がある。

SpotBugsのバージョンも少し古くなっており、最新版までにいくつかのバグフィックスも含まれていることもあるため、合わせて最新化しておく。