### PR TITLE
guavaの依存関係の復元とJBeretに最低限必要な依存関係についてのバージョン見直し

### DIFF
--- a/nablarch-batch-ee/pom.xml
+++ b/nablarch-batch-ee/pom.xml
@@ -31,7 +31,7 @@
     <nablarch.db.schema>PUBLIC</nablarch.db.schema>
     
     <!-- ライブラリのバージョン -->
-    <jberet.version>2.1.1.Final</jberet.version>
+    <jberet.version>2.1.4.Final</jberet.version>
     
   </properties>
 
@@ -306,25 +306,30 @@
     <dependency>
       <groupId>org.jboss.marshalling</groupId>
       <artifactId>jboss-marshalling</artifactId>
-      <version>2.0.12.Final</version>
+      <version>2.1.3.Final</version>
     </dependency>
     <dependency>
       <groupId>org.jboss.logging</groupId>
       <artifactId>jboss-logging</artifactId>
-      <version>3.4.3.Final</version>
+      <version>3.5.3.Final</version>
     </dependency>
     <dependency>
       <groupId>org.jboss.weld</groupId>
       <artifactId>weld-core-impl</artifactId>
-      <version>5.0.0.SP1</version>
+      <version>5.0.1.Final</version>
     </dependency>
     <dependency>
       <groupId>org.wildfly.security</groupId>
       <artifactId>wildfly-elytron-security-manager</artifactId>
-      <version>1.19.0.Final</version>
+      <version>2.2.2.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>32.1.1-jre</version>
     </dependency>
 
-    <!-- JBereteをJavaSEで動作させるための依存関係 -->
+    <!-- JBeretをJavaSEで動作させるための依存関係 -->
     <dependency>
       <groupId>org.jberet</groupId>
       <artifactId>jberet-se</artifactId>
@@ -333,7 +338,7 @@
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
       <artifactId>weld-se-core</artifactId>
-      <version>5.0.0.SP1</version>
+      <version>5.0.1.Final</version>
     </dependency>
 
     <!--


### PR DESCRIPTION
https://github.com/nablarch/nablarch-example-batch-ee/pull/89 、https://github.com/nablarch/nablarch-example-batch-ee/pull/90 で対応した通り、guavaを復元し、JBeretに関連するライブラリのバージョンを修正しました。