### PR TITLE
Jettyの一時ディレクトリをtarget配下に変更したため、不要になったmaven-clean-pluginのwork/jsp 削除の定義を削除

### DIFF
--- a/nablarch-container-web/pom.xml
+++ b/nablarch-container-web/pom.xml
@@ -372,21 +372,6 @@
           <webXml>${webxml.path}</webXml>
         </configuration>
       </plugin>
-      <!--
-      NablarchのテスティングフレームワークがJSPのコンパイル結果を格納するディレクトリを、
-      mvn clean時に削除するように設定。
-      -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-clean-plugin</artifactId>
-        <configuration>
-          <filesets>
-            <fileset>
-              <directory>work/jsp</directory>
-            </fileset>
-          </filesets>
-        </configuration>
-      </plugin>
       <!-- Dockerコンテナ化 -->
       <plugin>
         <groupId>com.google.cloud.tools</groupId>

--- a/nablarch-web/pom.xml
+++ b/nablarch-web/pom.xml
@@ -400,21 +400,6 @@
           </archive>
         </configuration>
       </plugin>
-      <!--
-      NablarchのテスティングフレームワークがJSPのコンパイル結果を格納するディレクトリを、
-      mvn clean時に削除するように設定。
-      -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-clean-plugin</artifactId>
-        <configuration>
-          <filesets>
-            <fileset>
-              <directory>work/jsp</directory>
-            </fileset>
-          </filesets>
-        </configuration>
-      </plugin>
       <!-- ================ここから任意で使用するツールの設定================ -->
       <!-- gsp-dba-maven-pluginで自動生成したソースをビルド時に使用するための設定 -->
       <plugin>


### PR DESCRIPTION
https://github.com/nablarch/nablarch-default-configuration/pull/34 より、maven-clean-plugin による work/jsp 削除が不要になったため対応しました。