### PR TITLE
Jettyで起動した際にJSTLのJARが重複する警告が出力されるので、Webアプリ側には含めないようにして警告を抑制

### DIFF
--- a/nablarch-container-web/pom.xml
+++ b/nablarch-container-web/pom.xml
@@ -363,6 +363,10 @@
           <httpConnector>
             <port>9080</port>
           </httpConnector>
+          <webApp>
+            <!-- Jettyに含まれるJSTLと重複するので、Webアプリに含まれるJSTLはJettyで起動する際には除外する -->
+            <webInfIncludeJarPattern><![CDATA[.*/[^/]+(?<!jakarta\.servlet\.jsp\.jstl-[^/]+)\.jar$]]></webInfIncludeJarPattern>
+          </webApp>
         </configuration>
       </plugin>
       <plugin>

--- a/nablarch-web/pom.xml
+++ b/nablarch-web/pom.xml
@@ -385,6 +385,10 @@
           <httpConnector>
             <port>9080</port>
           </httpConnector>
+          <webApp>
+            <!-- Jettyに含まれるJSTLと重複するので、Webアプリに含まれるJSTLはJettyで起動する際には除外する -->
+            <webInfIncludeJarPattern><![CDATA[.*/[^/]+(?<!jakarta\.servlet\.jsp\.jstl-[^/]+)\.jar$]]></webInfIncludeJarPattern>
+          </webApp>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
nablarch-fw-web-tagにJSTL（API、実装）が含まれるがJettyにもJSTLは含まれているため、mvn jetty:runで起動した際にJARに含まれるクラスが重複していることを警告されるので修正。

具体的には、Webアプリ側に含まれてるJSTL（API、実装）をJettyにデプロイする際に除外するように設定した。

対象は以下のアーキタイプ。

- nablarch-web
- nablarch-container-web

JAX-RSはJSTLを含んでいないので除外。

動作確認としては、以下を実施。

- 修正したアーキタイプからブランクプロジェクトを作成し、疎通確認用のJSPを表示
  - カスタムタグが含まれているのでJSTLの動作確認を兼ねる
- Jetty起動時にJSTLに関する警告が出力されないことを確認
  - 追加したプロパティを削除すると警告が出力されることも確認