### PR TITLE
アーキタイプおよびテンプレートプロジェクトの親pomから、生成プロジェクトに引き継ぐべきではない情報を削除

### DIFF
--- a/archetype-build-parent.xml
+++ b/archetype-build-parent.xml
@@ -5,6 +5,31 @@
   <artifactId>archetype-build-parent</artifactId>
   <version>1.0.0</version>
   <packaging>pom</packaging>
+
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <id>nablarch</id>
+      <name>Nablarch</name>
+      <email>nablarch@tis.co.jp</email>
+      <organization>Nablarch</organization>
+      <organizationUrl>https://github.com/nablarch</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:git://github.com/nablarch/nablarch/nablarch-single-module-archetype.git</connection>
+    <developerConnection>scm:git:ssh://github.com/nablarch/nablarch/nablarch-single-module-archetype.git</developerConnection>
+    <url>https://github.com/nablarch/nablarch-single-module-archetype/tree/master</url>
+    <tag>HEAD</tag>
+  </scm>
+
   <build>
     <plugins>
       <plugin>

--- a/nablarch-archetype-parent/pom.xml
+++ b/nablarch-archetype-parent/pom.xml
@@ -19,30 +19,6 @@
   <description>Nablarch Framework.</description>
   <url>https://github.com/nablarch</url>
 
-  <licenses>
-    <license>
-      <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-    </license>
-  </licenses>
-
-  <developers>
-    <developer>
-      <id>nablarch</id>
-      <name>Nablarch</name>
-      <email>nablarch@tis.co.jp</email>
-      <organization>Nablarch</organization>
-      <organizationUrl>https://github.com/nablarch</organizationUrl>
-    </developer>
-  </developers>
-
-  <scm>
-    <connection>scm:git:git://github.com/nablarch/nablarch/nablarch-single-module-archetype.git</connection>
-    <developerConnection>scm:git:ssh://github.com/nablarch/nablarch/nablarch-single-module-archetype.git</developerConnection>
-    <url>https://github.com/nablarch/nablarch-single-module-archetype/tree/master</url>
-    <tag>HEAD</tag>
-  </scm>
-
   <properties>
     <java.version>17</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>

--- a/pre-create-maven-archetype-batch-ee.sh
+++ b/pre-create-maven-archetype-batch-ee.sh
@@ -22,6 +22,8 @@ sed -i -e "s/com\/nablarch\/archetype/\${packageInPathFormat}/g" pom.xml
 sed -i -e "s/      <artifactId>\${rootArtifactId}<\/artifactId>/      <artifactId>nablarch-batch-ee<\/artifactId>/g" pom.xml
 # configファイル中のパッケージを置換文字列にする。
 sed -i -e "s/com\.nablarch\.archetype/\${package}/g" src/main/resources/*.properties
+# SQLファイルを移動。
+mv src/main/resources/com/nablarch/archetype/entity/*.sql src/main/resources/entity/
 # 想定箇所以外が${version}に置換されている可能性があるため、pom.xml以外の置換は元に戻す
 # `archetype_version` にはnablarch-archetype-parentのバージョンが入っているが、アーキタイプのバージョンと一致しているため問題ない。
 archetype_version=`grep -m 1 "<version>" pom.xml | awk -F '[><]' '{print $3}'`

--- a/pre-create-maven-archetype-batch-ee.sh
+++ b/pre-create-maven-archetype-batch-ee.sh
@@ -22,8 +22,6 @@ sed -i -e "s/com\/nablarch\/archetype/\${packageInPathFormat}/g" pom.xml
 sed -i -e "s/      <artifactId>\${rootArtifactId}<\/artifactId>/      <artifactId>nablarch-batch-ee<\/artifactId>/g" pom.xml
 # configファイル中のパッケージを置換文字列にする。
 sed -i -e "s/com\.nablarch\.archetype/\${package}/g" src/main/resources/*.properties
-# SQLファイルを移動。
-mv src/main/resources/com/nablarch/archetype/entity/*.sql src/main/resources/entity/
 # 想定箇所以外が${version}に置換されている可能性があるため、pom.xml以外の置換は元に戻す
 # `archetype_version` にはnablarch-archetype-parentのバージョンが入っているが、アーキタイプのバージョンと一致しているため問題ない。
 archetype_version=`grep -m 1 "<version>" pom.xml | awk -F '[><]' '{print $3}'`


### PR DESCRIPTION
## 修正内容

アーキタイプおよびテンプレートプロジェクトの親pom（`nablarch-archetype-parent`）から、生成プロジェクトに引き継ぐべきではない情報を削除する。

具体的には、以下の3つ。

- licenses
- developers
- scm

これらは[Maven Centralへのデプロイには必要な情報](https://central.sonatype.org/publish/requirements/)だが、アーキタイプから生成される各プロジェクトに引き継ぐべき情報ではない。

現在のアーキタイプ生成の仕組みは、テンプレートとなっているプロジェクトからMaven Archetype Pluginによりアーキタイププロジェクトを生成しており、[この時にテンプレートプロジェクトおよび親pom（`nablarch-archetype-parent`）からlicences、developers、scmも引き継いでしまう](https://github.com/apache/maven-archetype/blob/maven-archetype-3.2.1/archetype-common/src/main/java/org/apache/maven/archetype/creator/FilesetArchetypeCreator.java#L410-L412)。

アーキタイププロジェクトの親pomはスクリプトで差し替えているため（`archetype-build-parent`）、こちらに定義を移動する。  
※ `archetype-build-parent`はMaven Centralにデプロイする必要がある

## 動作確認

`nablarch-archetype-parent`から対象の情報を削除（`archetype-build-parent`へ移動）して`mvn install`した後に、以下の内容を確認。

- nablarch-web
  - [x] アーキタイププロジェクト（`nablarch-web-archetype`）から削除対象の情報がなくなっていること
  - [x] アーキタイプからプロジェクトが作成できること
  - [x] 生成されたプロジェクトで`mvn test`が成功すること
- nablarch-jaxrs
  - [x] アーキタイププロジェクト（`nablarch-jaxrs-archetype`）から削除対象の情報がなくなっていること
  - [x] アーキタイプからプロジェクトが作成できること
  - [x] 生成されたプロジェクトで`mvn test`が成功すること
- nablarch-batch
  - [x] アーキタイププロジェクト（`nablarch-batch-archetype`）から削除対象の情報がなくなっていること
  - [x] アーキタイプからプロジェクトが作成できること
  - [x] 生成されたプロジェクトで`mvn test`が成功すること
- nablarch-batch-ee
  - [x] アーキタイププロジェクト（`nablarch-batch-ee-archetype`）から削除対象の情報がなくなっていること
  - [x] アーキタイプからプロジェクトが作成できること
  - [x] 生成されたプロジェクトで`mvn test`が成功すること
- nablarch-batch-dbless
  - [x] アーキタイププロジェクト（`nablarch-batch-dbless-archetype`）から削除対象の情報がなくなっていること
  - [x] アーキタイプからプロジェクトが作成できること
  - [x] 生成されたプロジェクトで`mvn test`が成功すること
- nablarch-container-web
  - [x] アーキタイププロジェクト（`nablarch-container-web-archetype`）から削除対象の情報がなくなっていること
  - [x] アーキタイプからプロジェクトが作成できること
  - [x] 生成されたプロジェクトで`mvn test`が成功すること
- nablarch-container-jaxrs
  - [x] アーキタイププロジェクト（`nablarch-container-jaxrs-archetype`）から削除対象の情報がなくなっていること
  - [x] アーキタイプからプロジェクトが作成できること
  - [x] 生成されたプロジェクトで`mvn test`が成功すること
- nablarch-container-batch
  - [x] アーキタイププロジェクト（`nablarch-container-batch-archetype`）から削除対象の情報がなくなっていること
  - [x] アーキタイプからプロジェクトが作成できること
  - [x] 生成されたプロジェクトで`mvn test`が成功すること
- nablarch-container-batch-dbless
  - [x] アーキタイププロジェクト（`nablarch-container-batch-dbless-archetype`）から削除対象の情報がなくなっていること
  - [x] アーキタイプからプロジェクトが作成できること
  - [x] 生成されたプロジェクトで`mvn test`が成功すること
