### PR TITLE
アーキタイプおよびテンプレートプロジェクトの親pomから、生成プロジェクトに引き継ぐべきではない情報を削除（v5）

### DIFF
--- a/archetype-build-parent.xml
+++ b/archetype-build-parent.xml
@@ -5,6 +5,31 @@
   <artifactId>archetype-build-parent</artifactId>
   <version>1.0.0</version>
   <packaging>pom</packaging>
+
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <id>nablarch</id>
+      <name>Nablarch</name>
+      <email>nablarch@tis.co.jp</email>
+      <organization>Nablarch</organization>
+      <organizationUrl>https://github.com/nablarch</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:git://github.com/nablarch/nablarch/nablarch-single-module-archetype.git</connection>
+    <developerConnection>scm:git:ssh://github.com/nablarch/nablarch/nablarch-single-module-archetype.git</developerConnection>
+    <url>https://github.com/nablarch/nablarch-single-module-archetype/tree/master</url>
+    <tag>HEAD</tag>
+  </scm>
+
   <build>
     <plugins>
       <plugin>

--- a/nablarch-archetype-parent/pom.xml
+++ b/nablarch-archetype-parent/pom.xml
@@ -19,30 +19,6 @@
   <description>Nablarch Framework.</description>
   <url>https://github.com/nablarch</url>
 
-  <licenses>
-    <license>
-      <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-    </license>
-  </licenses>
-
-  <developers>
-    <developer>
-      <id>nablarch</id>
-      <name>Nablarch</name>
-      <email>nablarch@tis.co.jp</email>
-      <organization>Nablarch</organization>
-      <organizationUrl>https://github.com/nablarch</organizationUrl>
-    </developer>
-  </developers>
-
-  <scm>
-    <connection>scm:git:git://github.com/nablarch/nablarch/nablarch-single-module-archetype.git</connection>
-    <developerConnection>scm:git:ssh://github.com/nablarch/nablarch/nablarch-single-module-archetype.git</developerConnection>
-    <url>https://github.com/nablarch/nablarch-single-module-archetype/tree/master</url>
-    <tag>HEAD</tag>
-  </scm>
-
   <properties>
     <java.version>1.8</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>


### PR DESCRIPTION
#171 のv5版

確認。

- nablarch-web
  - [x] アーキタイププロジェクト（`nablarch-web-archetype`）から削除対象の情報がなくなっていること
  - [x] アーキタイプからプロジェクトが作成できること
  - [x] 生成されたプロジェクトで`mvn test`が成功すること
- nablarch-jaxrs
  - [x] アーキタイププロジェクト（`nablarch-jaxrs-archetype`）から削除対象の情報がなくなっていること
  - [x] アーキタイプからプロジェクトが作成できること
  - [x] 生成されたプロジェクトで`mvn test`が成功すること
- nablarch-batch
  - [x] アーキタイププロジェクト（`nablarch-batch-archetype`）から削除対象の情報がなくなっていること
  - [x] アーキタイプからプロジェクトが作成できること
  - [x] 生成されたプロジェクトで`mvn test`が成功すること
- nablarch-batch-ee
  - [x] アーキタイププロジェクト（`nablarch-batch-ee-archetype`）から削除対象の情報がなくなっていること
  - [x] アーキタイプからプロジェクトが作成できること
  - [x] 生成されたプロジェクトで`mvn test`が成功すること
- nablarch-batch-dbless
  - [x] アーキタイププロジェクト（`nablarch-batch-dbless-archetype`）から削除対象の情報がなくなっていること
  - [x] アーキタイプからプロジェクトが作成できること
  - [x] 生成されたプロジェクトで`mvn test`が成功すること
- nablarch-container-web
  - [x] アーキタイププロジェクト（`nablarch-container-web-archetype`）から削除対象の情報がなくなっていること
  - [x] アーキタイプからプロジェクトが作成できること
  - [x] 生成されたプロジェクトで`mvn test`が成功すること
- nablarch-container-jaxrs
  - [x] アーキタイププロジェクト（`nablarch-container-jaxrs-archetype`）から削除対象の情報がなくなっていること
  - [x] アーキタイプからプロジェクトが作成できること
  - [x] 生成されたプロジェクトで`mvn test`が成功すること
- nablarch-container-batch
  - [x] アーキタイププロジェクト（`nablarch-container-batch-archetype`）から削除対象の情報がなくなっていること
  - [x] アーキタイプからプロジェクトが作成できること
  - [x] 生成されたプロジェクトで`mvn test`が成功すること
- nablarch-container-batch-dbless
  - [x] アーキタイププロジェクト（`nablarch-container-batch-dbless-archetype`）から削除対象の情報がなくなっていること
  - [x] アーキタイプからプロジェクトが作成できること
  - [x] 生成されたプロジェクトで`mvn test`が成功すること