### PR TITLE
parentおよびwebアーキタイプのMavenプラグインを最新化

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ mvn install
 ```
 # nablarch-webプロジェクトをベースにアーキタイプを生成
 pushd nablarch-web
-mvn clean archetype:create-from-project
+mvn clean archetype:2.4:create-from-project
 popd
 
 # 独自のカスタマイズを加える
@@ -55,7 +55,7 @@ mvn install
 ```
 # nablarch-jaxrsプロジェクトをベースにアーキタイプを生成
 pushd nablarch-jaxrs
-mvn clean archetype:create-from-project
+mvn clean archetype:2.4:create-from-project
 popd
 
 # 独自のカスタマイズを加える
@@ -70,7 +70,7 @@ mvn install
 ```
 # nablarch-batchプロジェクトをベースにアーキタイプを生成
 pushd nablarch-batch
-mvn clean archetype:create-from-project
+mvn clean archetype:2.4:create-from-project
 popd
 
 # 独自のカスタマイズを加える
@@ -85,7 +85,7 @@ mvn install
 ```
 # nablarch-batch-eeプロジェクトをベースにアーキタイプを生成
 pushd nablarch-batch-ee
-mvn clean archetype:create-from-project
+mvn clean archetype:2.4:create-from-project
 popd
 
 # 独自のカスタマイズを加える
@@ -100,7 +100,7 @@ mvn install
 ```
 # nablarch-batch-dblessプロジェクトをベースにアーキタイプを生成
 pushd nablarch-batch-dbless
-mvn clean archetype:create-from-project
+mvn clean archetype:2.4:create-from-project
 popd
 
 # 独自のカスタマイズを加える
@@ -115,7 +115,7 @@ mvn install
 ```
 # nablarch-container-webプロジェクトをベースにアーキタイプを生成
 pushd nablarch-container-web
-mvn clean archetype:create-from-project
+mvn clean archetype:2.4:create-from-project
 popd
 
 # 独自のカスタマイズを加える
@@ -130,7 +130,7 @@ mvn install
 ```
 # nablarch-container-jaxrsプロジェクトをベースにアーキタイプを生成
 pushd nablarch-container-jaxrs
-mvn clean archetype:create-from-project
+mvn clean archetype:2.4:create-from-project
 popd
 
 # 独自のカスタマイズを加える
@@ -145,7 +145,7 @@ mvn install
 ```
 # nablarch-container-batchプロジェクトをベースにアーキタイプを生成
 pushd nablarch-container-batch
-mvn clean archetype:create-from-project
+mvn clean archetype:2.4:create-from-project
 popd
 
 # 独自のカスタマイズを加える
@@ -160,7 +160,7 @@ mvn install
 ```
 # nablarch-container-batch-dblessプロジェクトをベースにアーキタイプを生成
 pushd nablarch-container-batch-dbless
-mvn clean archetype:create-from-project
+mvn clean archetype:2.4:create-from-project
 popd
 
 # 独自のカスタマイズを加える

--- a/archetype-build-parent.xml
+++ b/archetype-build-parent.xml
@@ -30,12 +30,18 @@
     <tag>HEAD</tag>
   </scm>
 
+  <properties>
+    <version.plugins.source>3.3.1</version.plugins.source>
+    <version.plugins.javadoc>3.10.0</version.plugins.javadoc>
+    <version.plugins.gpg>3.2.5</version.plugins.gpg>
+  </properties>
+
   <build>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.2.1</version>
+        <version>${version.plugins.source}</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -48,7 +54,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>${version.plugins.javadoc}</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -61,7 +67,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
-        <version>1.5</version>
+        <version>${version.plugins.gpg}</version>
         <executions>
           <execution>
             <id>sign-artifacts</id>

--- a/nablarch-archetype-parent/pom.xml
+++ b/nablarch-archetype-parent/pom.xml
@@ -30,21 +30,21 @@
     <version.plugins.gsp.dba>5.1.0-SNAPSHOT</version.plugins.gsp.dba>
     <version.plugins.compiler>3.13.0</version.plugins.compiler>
     <version.plugins.surefire>3.5.0</version.plugins.surefire>
-    <version.plugins.antrun>1.7</version.plugins.antrun>
+    <version.plugins.antrun>3.1.0</version.plugins.antrun>
     <version.plugins.war>3.4.0</version.plugins.war>
-    <version.plugins.assembly>2.5.1</version.plugins.assembly>
+    <version.plugins.assembly>3.7.1</version.plugins.assembly>
     <version.plugins.clean>2.5</version.plugins.clean>
     <version.plugins.deploy>2.8.2</version.plugins.deploy>
     <version.plugins.dependency>2.9</version.plugins.dependency>
     <version.plugins.failsafe>2.18</version.plugins.failsafe>
     <version.plugins.install>2.5.2</version.plugins.install>
-    <version.plugins.jar>2.5</version.plugins.jar>
+    <version.plugins.jar>3.4.2</version.plugins.jar>
     <version.plugins.javadoc>3.4.1</version.plugins.javadoc>
-    <version.plugins.resources>2.7</version.plugins.resources>
+    <version.plugins.resources>3.3.1</version.plugins.resources>
     <version.plugins.source>2.4</version.plugins.source>
-    <version.plugins.jacoco>0.8.11</version.plugins.jacoco>
+    <version.plugins.jacoco>0.8.12</version.plugins.jacoco>
     <version.plugins.build-helper-maven>3.6.0</version.plugins.build-helper-maven>
-    <version.plugins.jib>3.3.1</version.plugins.jib>
+    <version.plugins.jib>3.4.3</version.plugins.jib>
     <version.plugins.spotbugs>4.8.6.2</version.plugins.spotbugs>
     <spotbugs.version>4.8.6</spotbugs.version>
     <version.plugins.release>3.1.1</version.plugins.release>

--- a/nablarch-archetype-parent/pom.xml
+++ b/nablarch-archetype-parent/pom.xml
@@ -39,9 +39,9 @@
     <version.plugins.failsafe>2.18</version.plugins.failsafe>
     <version.plugins.install>2.5.2</version.plugins.install>
     <version.plugins.jar>3.4.2</version.plugins.jar>
-    <version.plugins.javadoc>3.4.1</version.plugins.javadoc>
+    <version.plugins.javadoc>3.10.0</version.plugins.javadoc>
     <version.plugins.resources>3.3.1</version.plugins.resources>
-    <version.plugins.source>2.4</version.plugins.source>
+    <version.plugins.source>3.3.1</version.plugins.source>
     <version.plugins.jacoco>0.8.12</version.plugins.jacoco>
     <version.plugins.build-helper-maven>3.6.0</version.plugins.build-helper-maven>
     <version.plugins.jib>3.4.3</version.plugins.jib>

--- a/nablarch-archetype-parent/pom.xml
+++ b/nablarch-archetype-parent/pom.xml
@@ -28,10 +28,10 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <version.plugins.gsp.dba>5.1.0-SNAPSHOT</version.plugins.gsp.dba>
-    <version.plugins.compiler>3.2</version.plugins.compiler>
-    <version.plugins.surefire>2.22.2</version.plugins.surefire>
+    <version.plugins.compiler>3.13.0</version.plugins.compiler>
+    <version.plugins.surefire>3.5.0</version.plugins.surefire>
     <version.plugins.antrun>1.7</version.plugins.antrun>
-    <version.plugins.war>3.3.2</version.plugins.war>
+    <version.plugins.war>3.4.0</version.plugins.war>
     <version.plugins.assembly>2.5.1</version.plugins.assembly>
     <version.plugins.clean>2.5</version.plugins.clean>
     <version.plugins.deploy>2.8.2</version.plugins.deploy>
@@ -43,10 +43,11 @@
     <version.plugins.resources>2.7</version.plugins.resources>
     <version.plugins.source>2.4</version.plugins.source>
     <version.plugins.jacoco>0.8.11</version.plugins.jacoco>
-    <version.plugins.build-helper-maven>1.9.1</version.plugins.build-helper-maven>
+    <version.plugins.build-helper-maven>3.6.0</version.plugins.build-helper-maven>
     <version.plugins.jib>3.3.1</version.plugins.jib>
     <version.plugins.spotbugs>4.8.6.2</version.plugins.spotbugs>
     <spotbugs.version>4.8.6</spotbugs.version>
+    <version.plugins.release>3.1.1</version.plugins.release>
     <version.plugins.unpublished.api.checker>1.0.0</version.plugins.unpublished.api.checker>
     <version.plugins.findsecbugs>1.13.0</version.plugins.findsecbugs>
     <version.nablarch.toolbox>6-NEXT-SNAPSHOT</version.nablarch.toolbox>
@@ -398,7 +399,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.1</version>
+        <version>${version.plugins.release}</version>
         <configuration>
           <tagNameFormat>@{project.version}</tagNameFormat>
           <allowTimestampedSnapshots>${release.allow.snapshot}</allowTimestampedSnapshots>

--- a/nablarch-container-jaxrs/pom.xml
+++ b/nablarch-container-jaxrs/pom.xml
@@ -31,7 +31,7 @@
      検証時と異なるバージョンが選択された場合、アプリケーションの動作に影響が出る可能性があるので、
      プロジェクトにおける検証が完了した段階で、バージョンを固定するために、イメージをダイジェストで指定することを推奨する。
     -->
-    <jib.from.image>tomcat:10.1.5-jdk17-temurin</jib.from.image>
+    <jib.from.image>tomcat:10.1.28-jdk17-temurin</jib.from.image>
   </properties>
 
   <!--
@@ -404,7 +404,7 @@
       <plugin>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-maven-plugin</artifactId>
-        <version>12.0.3</version>
+        <version>12.0.12</version>
         <configuration>
           <httpConnector>
             <port>9080</port>

--- a/nablarch-container-web/pom.xml
+++ b/nablarch-container-web/pom.xml
@@ -37,7 +37,7 @@
      検証時と異なるバージョンが選択された場合、アプリケーションの動作に影響が出る可能性があるので、
      プロジェクトにおける検証が完了した段階で、バージョンを固定するために、イメージをダイジェストで指定することを推奨する。
     -->
-    <jib.from.image>tomcat:10.1.5-jdk17-temurin</jib.from.image>
+    <jib.from.image>tomcat:10.1.28-jdk17-temurin</jib.from.image>
   </properties>
 
   <!--
@@ -358,7 +358,7 @@
       <plugin>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-maven-plugin</artifactId>
-        <version>12.0.3</version>
+        <version>12.0.12</version>
         <configuration>
           <httpConnector>
             <port>9080</port>

--- a/nablarch-jaxrs/pom.xml
+++ b/nablarch-jaxrs/pom.xml
@@ -432,7 +432,7 @@
       <plugin>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-maven-plugin</artifactId>
-        <version>12.0.3</version>
+        <version>12.0.12</version>
         <configuration>
           <httpConnector>
             <port>9080</port>

--- a/nablarch-web/pom.xml
+++ b/nablarch-web/pom.xml
@@ -380,7 +380,7 @@
       <plugin>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-maven-plugin</artifactId>
-        <version>12.0.3</version>
+        <version>12.0.12</version>
         <configuration>
           <httpConnector>
             <port>9080</port>


### PR DESCRIPTION
# 概要

アーキタイプに関するMavenプロジェクトに定義してあるMavenプラグインのバージョンを最新化します。

削除予定のプラグインについては最新化していません。  

# 動作確認

- nablarch-web
  - [x] ブランクプロジェクトが作成できること
  - [x] `mvn clean package`が実行できること（基本的なビルドプロセスを実行し、多くのプラグインをカバーできていること）
  - [x] `mvn jetty:run`が実行でき、疎通確認ページが参照できること
  - [x] `mvn jacoco:report`が実行でき、カバレッジレポートを確認できること
  - [x] `mvn verify -DskipTests=true`が実行でき、JSP静的解析ツールが実行できること
  - [x] `mvn spotbugs:check`が実行でき、SpotBugsが実行できること
  - [x] `mvn release:help`が実行できること（Maven Release Pluginのバージョン指定に誤りがないことを確認）
- nablarch-jaxrs
  - [x] ブランクプロジェクトが作成できること
  - [x] `mvn clean package`が実行できること（基本的なビルドプロセスを実行し、多くのプラグインをカバーできていること）
  - [x] `mvn jetty:run`が実行でき、疎通確認用のAPIが呼び出せること
  - [x] `mvn jacoco:report`が実行でき、カバレッジレポートを確認できること
  - [x] `mvn spotbugs:check`が実行でき、SpotBugsが実行できること
  - [x] `mvn release:help`が実行できること（Maven Release Pluginのバージョン指定に誤りがないことを確認）
- nablarch-batch
  - [x] ブランクプロジェクトが作成できること
  - [x] `mvn clean install`が実行できること（基本的なビルドプロセスを実行し、多くのプラグインをカバーできていること）
  - [x] `mvn exec:java`が実行でき、起動テストができること
  - [x] `mvn jacoco:report`が実行でき、カバレッジレポートを確認できること
  - [x] `mvn spotbugs:check`が実行でき、SpotBugsが実行できること
  - [x] `mvn release:help`が実行できること（Maven Release Pluginのバージョン指定に誤りがないことを確認）
- nablarch-batch-ee
  - [x] ブランクプロジェクトが作成できること
  - [x] `mvn clean install`が実行できること（基本的なビルドプロセスを実行し、多くのプラグインをカバーできていること）
  - [x] `mvn exec:java`が実行でき、起動テストができること
  - [x] `mvn jacoco:report`が実行でき、カバレッジレポートを確認できること
  - [x] `mvn spotbugs:check`が実行でき、SpotBugsが実行できること
  - [x] `mvn release:help`が実行できること（Maven Release Pluginのバージョン指定に誤りがないことを確認）
- nablarch-batch-dbless
  - [x] ブランクプロジェクトが作成できること
  - [x] `mvn clean install`が実行できること（基本的なビルドプロセスを実行し、多くのプラグインをカバーできていること）
  - [x] `mvn exec:java`が実行でき、起動テストができること
  - [x] `mvn jacoco:report`が実行でき、カバレッジレポートを確認できること
  - [x] `mvn spotbugs:check`が実行でき、SpotBugsが実行できること
  - [x] `mvn release:help`が実行できること（Maven Release Pluginのバージョン指定に誤りがないことを確認）
- nablarch-container-web
  - [x] ブランクプロジェクトが作成できること
  - [x] `mvn clean package jib:dockerBuild`が実行できること（基本的なビルドプロセスを実行し、多くのプラグインをカバーできていること、Dockerイメージが作成できること）
  - [x] `mvn jetty:run`が実行でき、疎通確認ページが参照できること
  - [x] `docker container run`で作成したコンテナを実行でき、疎通確認ができること
  - [x] `mvn jacoco:report`が実行でき、カバレッジレポートを確認できること
  - [x] `mvn verify -DskipTests=true`が実行でき、JSP静的解析ツールが実行できること
  - [x] `mvn spotbugs:check`が実行でき、SpotBugsが実行できること
  - [x] `mvn release:help`が実行できること（Maven Release Pluginのバージョン指定に誤りがないことを確認）
- nablarch-container-jaxrs
  - [x] ブランクプロジェクトが作成できること
  - [x] `mvn clean package jib:dockerBuild`が実行できること（基本的なビルドプロセスを実行し、多くのプラグインをカバーできていること、Dockerイメージが作成できること）
  - [x] `mvn jetty:run`が実行でき、疎通確認ページが参照できること
  - [x] `docker container run`で作成したコンテナを実行でき、疎通確認ができること
  - [x] `mvn jacoco:report`が実行でき、カバレッジレポートを確認できること
  - [x] `mvn spotbugs:check`が実行でき、SpotBugsが実行できること
  - [x] `mvn release:help`が実行できること（Maven Release Pluginのバージョン指定に誤りがないことを確認）
- nablarch-container-batch
  - [x] ブランクプロジェクトが作成できること
  - [x] `mvn clean package jib:dockerBuild`が実行できること（基本的なビルドプロセスを実行し、多くのプラグインをカバーできていること、Dockerイメージが作成できること）
  - [x] `mvn exec:java`が実行でき、起動テストができること
  - [x] `docker container run`で作成したコンテナを実行でき、疎通確認ができること
  - [x] `mvn jacoco:report`が実行でき、カバレッジレポートを確認できること
  - [x] `mvn spotbugs:check`が実行でき、SpotBugsが実行できること
  - [x] `mvn release:help`が実行できること（Maven Release Pluginのバージョン指定に誤りがないことを確認）
- nablarch-batch-container-dbless
  - [x] ブランクプロジェクトが作成できること
  - [x] `mvn clean package jib:dockerBuild`が実行できること（基本的なビルドプロセスを実行し、多くのプラグインをカバーできていること、Dockerイメージが作成できること）
  - [x] `mvn exec:java`が実行でき、起動テストができること
  - [x] `docker container run`で作成したコンテナを実行でき、疎通確認ができること
  - [x] `mvn jacoco:report`が実行でき、カバレッジレポートを確認できること
  - [x] `mvn spotbugs:check`が実行でき、SpotBugsが実行できること
  - [x] `mvn release:help`が実行できること（Maven Release Pluginのバージョン指定に誤りがないことを確認）
