### PR TITLE
使用していないMavenプラグイン設定を削除

### DIFF
--- a/nablarch-archetype-parent/pom.xml
+++ b/nablarch-archetype-parent/pom.xml
@@ -33,11 +33,6 @@
     <version.plugins.antrun>3.1.0</version.plugins.antrun>
     <version.plugins.war>3.4.0</version.plugins.war>
     <version.plugins.assembly>3.7.1</version.plugins.assembly>
-    <version.plugins.clean>2.5</version.plugins.clean>
-    <version.plugins.deploy>2.8.2</version.plugins.deploy>
-    <version.plugins.dependency>2.9</version.plugins.dependency>
-    <version.plugins.failsafe>2.18</version.plugins.failsafe>
-    <version.plugins.install>2.5.2</version.plugins.install>
     <version.plugins.jar>3.4.2</version.plugins.jar>
     <version.plugins.javadoc>3.10.0</version.plugins.javadoc>
     <version.plugins.resources>3.3.1</version.plugins.resources>
@@ -264,21 +259,6 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-clean-plugin</artifactId>
-          <version>${version.plugins.clean}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-dependency-plugin</artifactId>
-          <version>${version.plugins.dependency}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-failsafe-plugin</artifactId>
-          <version>${version.plugins.failsafe}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
           <version>${version.plugins.jar}</version>
         </plugin>
@@ -406,74 +386,5 @@
         </configuration>
       </plugin>
     </plugins>
-    <extensions>
-      <extension>
-        <groupId>org.apache.maven.wagon</groupId>
-        <artifactId>wagon-webdav-jackrabbit</artifactId>
-        <version>3.0.0</version>
-      </extension>
-    </extensions>
   </build>
-
-
-  <profiles>
-    <profile>
-      <id>ossrh</id>
-      <distributionManagement>
-        <repository>
-          <id>nablarch.staging</id>
-          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-        </repository>
-        <snapshotRepository>
-          <id>nablarch.snapshot</id>
-          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-      </distributionManagement>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-source-plugin</artifactId>
-            <version>2.2.1</version>
-            <executions>
-              <execution>
-                <id>attach-sources</id>
-                <goals>
-                  <goal>jar-no-fork</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.9.1</version>
-            <executions>
-              <execution>
-                <id>attach-javadocs</id>
-                <goals>
-                  <goal>jar</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.5</version>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-  
 </project>

--- a/nablarch-archetype-parent/pom.xml
+++ b/nablarch-archetype-parent/pom.xml
@@ -31,8 +31,11 @@
     <version.plugins.compiler>3.13.0</version.plugins.compiler>
     <version.plugins.surefire>3.5.0</version.plugins.surefire>
     <version.plugins.antrun>3.1.0</version.plugins.antrun>
+    <version.plugins.jetty>12.0.12</version.plugins.jetty>
     <version.plugins.war>3.4.0</version.plugins.war>
     <version.plugins.assembly>3.7.1</version.plugins.assembly>
+    <version.plugins.deploy>3.1.3</version.plugins.deploy>
+    <version.plugins.install>3.1.3</version.plugins.install>
     <version.plugins.jar>3.4.2</version.plugins.jar>
     <version.plugins.javadoc>3.10.0</version.plugins.javadoc>
     <version.plugins.resources>3.3.1</version.plugins.resources>
@@ -253,9 +256,24 @@
           <version>${version.plugins.war}</version>
         </plugin>
         <plugin>
+          <groupId>org.eclipse.jetty.ee10</groupId>
+          <artifactId>jetty-ee10-maven-plugin</artifactId>
+          <version>${version.plugins.jetty}</version>
+        </plugin>
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
           <version>${version.plugins.assembly}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>${version.plugins.install}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>${version.plugins.deploy}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/nablarch-batch-ee/pom.xml
+++ b/nablarch-batch-ee/pom.xml
@@ -147,7 +147,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-install-plugin</artifactId>
-            <version>${version.plugins.install}</version>
             <executions>
               <!-- gsp-dba-maven-pluginで生成したdumpファイルをinstallするための設定 -->
               <execution>
@@ -168,7 +167,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-deploy-plugin</artifactId>
-            <version>${version.plugins.deploy}</version>
             <executions>
               <!-- gsp-dba-maven-pluginで生成したdumpファイルをdeployするための設定 -->
               <execution>

--- a/nablarch-batch/pom.xml
+++ b/nablarch-batch/pom.xml
@@ -142,7 +142,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-install-plugin</artifactId>
-            <version>${version.plugins.install}</version>
             <executions>
               <!-- gsp-dba-maven-pluginで生成したdumpファイルをinstallするための設定 -->
               <execution>
@@ -163,7 +162,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-deploy-plugin</artifactId>
-            <version>${version.plugins.deploy}</version>
             <executions>
               <!-- gsp-dba-maven-pluginで生成したdumpファイルをdeployするための設定 -->
               <execution>

--- a/nablarch-container-batch/pom.xml
+++ b/nablarch-container-batch/pom.xml
@@ -124,7 +124,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-install-plugin</artifactId>
-            <version>${version.plugins.install}</version>
             <executions>
               <!-- gsp-dba-maven-pluginで生成したdumpファイルをinstallするための設定 -->
               <execution>
@@ -145,7 +144,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-deploy-plugin</artifactId>
-            <version>${version.plugins.deploy}</version>
             <executions>
               <!-- gsp-dba-maven-pluginで生成したdumpファイルをdeployするための設定 -->
               <execution>

--- a/nablarch-container-jaxrs/pom.xml
+++ b/nablarch-container-jaxrs/pom.xml
@@ -121,7 +121,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-install-plugin</artifactId>
-            <version>${version.plugins.install}</version>
             <executions>
               <!-- gsp-dba-maven-pluginで生成したdumpファイルをinstallするための設定 -->
               <execution>
@@ -142,7 +141,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-deploy-plugin</artifactId>
-            <version>${version.plugins.deploy}</version>
             <executions>
               <!-- gsp-dba-maven-pluginで生成したdumpファイルをdeployするための設定 -->
               <execution>
@@ -404,7 +402,6 @@
       <plugin>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-maven-plugin</artifactId>
-        <version>12.0.12</version>
         <configuration>
           <httpConnector>
             <port>9080</port>

--- a/nablarch-container-web/pom.xml
+++ b/nablarch-container-web/pom.xml
@@ -127,7 +127,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-install-plugin</artifactId>
-            <version>${version.plugins.install}</version>
             <executions>
               <!-- gsp-dba-maven-pluginで生成したdumpファイルをinstallするための設定 -->
               <execution>
@@ -148,7 +147,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-deploy-plugin</artifactId>
-            <version>${version.plugins.deploy}</version>
             <executions>
               <!-- gsp-dba-maven-pluginで生成したdumpファイルをdeployするための設定 -->
               <execution>
@@ -358,7 +356,6 @@
       <plugin>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-maven-plugin</artifactId>
-        <version>12.0.12</version>
         <configuration>
           <httpConnector>
             <port>9080</port>

--- a/nablarch-jaxrs/pom.xml
+++ b/nablarch-jaxrs/pom.xml
@@ -166,7 +166,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-install-plugin</artifactId>
-            <version>${version.plugins.install}</version>
             <executions>
               <!-- gsp-dba-maven-pluginで生成したdumpファイルをinstallするための設定 -->
               <execution>
@@ -187,7 +186,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-deploy-plugin</artifactId>
-            <version>${version.plugins.deploy}</version>
             <executions>
               <!-- gsp-dba-maven-pluginで生成したdumpファイルをdeployするための設定 -->
               <execution>
@@ -432,7 +430,6 @@
       <plugin>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-maven-plugin</artifactId>
-        <version>12.0.12</version>
         <configuration>
           <httpConnector>
             <port>9080</port>

--- a/nablarch-web/pom.xml
+++ b/nablarch-web/pom.xml
@@ -172,7 +172,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-install-plugin</artifactId>
-            <version>${version.plugins.install}</version>
             <executions>
               <!-- gsp-dba-maven-pluginで生成したdumpファイルをinstallするための設定 -->
               <execution>
@@ -193,7 +192,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-deploy-plugin</artifactId>
-            <version>${version.plugins.deploy}</version>
             <executions>
               <!-- gsp-dba-maven-pluginで生成したdumpファイルをdeployするための設定 -->
               <execution>
@@ -380,7 +378,6 @@
       <plugin>
         <groupId>org.eclipse.jetty.ee10</groupId>
         <artifactId>jetty-ee10-maven-plugin</artifactId>
-        <version>12.0.12</version>
         <configuration>
           <httpConnector>
             <port>9080</port>


### PR DESCRIPTION
# 概要

アーキタイプ（ブランクプロジェクト）で使用しないMavenプラグインおよび関連する設定を削除。  
ossrhのプロファイルもアーキタイプには不要なので削除。

また、JettyやDeploy、Installプラグインについてはアーキタイプの親側にバージョン定義をまとめた。  
（Deploy、Installについてはバージョンも更新）

# 動作確認

- nablarch-web
  - [x] ブランクプロジェクトが作成できること
  - [x] `mvn clean package`が実行できること（基本的なビルドプロセスを実行し、多くのプラグインをカバーできていること）
  - [x] `mvn jetty:run`が実行でき、疎通確認ページが参照できること
  - [x] `mvn jacoco:report`が実行でき、カバレッジレポートを確認できること
  - [x] `mvn verify -DskipTests=true`が実行でき、JSP静的解析ツールが実行できること
  - [x] `mvn spotbugs:check`が実行でき、SpotBugsが実行できること
  - [x] `mvn release:help`が実行できること（Maven Release Pluginのバージョン指定に誤りがないことを確認）
- nablarch-jaxrs
  - [x] ブランクプロジェクトが作成できること
  - [x] `mvn clean package`が実行できること（基本的なビルドプロセスを実行し、多くのプラグインをカバーできていること）
  - [x] `mvn jetty:run`が実行でき、疎通確認用のAPIが呼び出せること
  - [x] `mvn jacoco:report`が実行でき、カバレッジレポートを確認できること
  - [x] `mvn spotbugs:check`が実行でき、SpotBugsが実行できること
  - [x] `mvn release:help`が実行できること（Maven Release Pluginのバージョン指定に誤りがないことを確認）
- nablarch-batch
  - [x] ブランクプロジェクトが作成できること
  - [x] `mvn clean install`が実行できること（基本的なビルドプロセスを実行し、多くのプラグインをカバーできていること）
  - [x] `mvn exec:java`が実行でき、起動テストができること
  - [x] `mvn jacoco:report`が実行でき、カバレッジレポートを確認できること
  - [x] `mvn spotbugs:check`が実行でき、SpotBugsが実行できること
  - [x] `mvn release:help`が実行できること（Maven Release Pluginのバージョン指定に誤りがないことを確認）
- nablarch-batch-ee
  - [x] ブランクプロジェクトが作成できること
  - [x] `mvn clean install`が実行できること（基本的なビルドプロセスを実行し、多くのプラグインをカバーできていること）
  - [x] `mvn exec:java`が実行でき、起動テストができること
  - [x] `mvn jacoco:report`が実行でき、カバレッジレポートを確認できること
  - [x] `mvn spotbugs:check`が実行でき、SpotBugsが実行できること
  - [x] `mvn release:help`が実行できること（Maven Release Pluginのバージョン指定に誤りがないことを確認）
- nablarch-batch-dbless
  - [x] ブランクプロジェクトが作成できること
  - [x] `mvn clean install`が実行できること（基本的なビルドプロセスを実行し、多くのプラグインをカバーできていること）
  - [x] `mvn exec:java`が実行でき、起動テストができること
  - [x] `mvn jacoco:report`が実行でき、カバレッジレポートを確認できること
  - [x] `mvn spotbugs:check`が実行でき、SpotBugsが実行できること
  - [x] `mvn release:help`が実行できること（Maven Release Pluginのバージョン指定に誤りがないことを確認）
- nablarch-container-web
  - [x] ブランクプロジェクトが作成できること
  - [x] `mvn clean package jib:dockerBuild`が実行できること（基本的なビルドプロセスを実行し、多くのプラグインをカバーできていること、Dockerイメージが作成できること）
  - [x] `mvn jetty:run`が実行でき、疎通確認ページが参照できること
  - [x] `docker container run`で作成したコンテナを実行でき、疎通確認ができること
  - [x] `mvn jacoco:report`が実行でき、カバレッジレポートを確認できること
  - [x] `mvn verify -DskipTests=true`が実行でき、JSP静的解析ツールが実行できること
  - [x] `mvn spotbugs:check`が実行でき、SpotBugsが実行できること
  - [x] `mvn release:help`が実行できること（Maven Release Pluginのバージョン指定に誤りがないことを確認）
- nablarch-container-jaxrs
  - [x] ブランクプロジェクトが作成できること
  - [x] `mvn clean package jib:dockerBuild`が実行できること（基本的なビルドプロセスを実行し、多くのプラグインをカバーできていること、Dockerイメージが作成できること）
  - [x] `mvn jetty:run`が実行でき、疎通確認ページが参照できること
  - [x] `docker container run`で作成したコンテナを実行でき、疎通確認ができること
  - [x] `mvn jacoco:report`が実行でき、カバレッジレポートを確認できること
  - [x] `mvn spotbugs:check`が実行でき、SpotBugsが実行できること
  - [x] `mvn release:help`が実行できること（Maven Release Pluginのバージョン指定に誤りがないことを確認）
- nablarch-container-batch
  - [x] ブランクプロジェクトが作成できること
  - [x] `mvn clean package jib:dockerBuild`が実行できること（基本的なビルドプロセスを実行し、多くのプラグインをカバーできていること、Dockerイメージが作成できること）
  - [x] `mvn exec:java`が実行でき、起動テストができること
  - [x] `docker container run`で作成したコンテナを実行でき、疎通確認ができること
  - [x] `mvn jacoco:report`が実行でき、カバレッジレポートを確認できること
  - [x] `mvn spotbugs:check`が実行でき、SpotBugsが実行できること
  - [x] `mvn release:help`が実行できること（Maven Release Pluginのバージョン指定に誤りがないことを確認）
- nablarch-container-batch-dbless
  - [x] ブランクプロジェクトが作成できること
  - [x] `mvn clean package jib:dockerBuild`が実行できること（基本的なビルドプロセスを実行し、多くのプラグインをカバーできていること、Dockerイメージが作成できること）
  - [x] `mvn exec:java`が実行でき、起動テストができること
  - [x] `docker container run`で作成したコンテナを実行でき、疎通確認ができること
  - [x] `mvn jacoco:report`が実行でき、カバレッジレポートを確認できること
  - [x] `mvn spotbugs:check`が実行でき、SpotBugsが実行できること
  - [ ] `mvn release:help`が実行できること（Maven Release Pluginのバージョン指定に誤りがないことを確認）