### PR TITLE
Maven Archetype Pluginの3系でアーキタイプを作成できるように対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ mvn install
 ## nablarch-web
 
 ```
-mvn org.apache.maven.plugins:maven-archetype-plugin:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion=xxx
+mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion=xxx
 ```
 (xxxの箇所は、適切なバージョンを指定してください)
 
@@ -203,7 +203,7 @@ mvn org.apache.maven.plugins:maven-archetype-plugin:generate -DarchetypeGroupId=
 ## nablarch-jaxrs
 
 ```
-mvn org.apache.maven.plugins:maven-archetype-plugin:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-jaxrs-archetype -DarchetypeVersion=xxx
+mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-jaxrs-archetype -DarchetypeVersion=xxx
 ```
 (xxxの箇所は、適切なバージョンを指定してください)
 
@@ -211,7 +211,7 @@ mvn org.apache.maven.plugins:maven-archetype-plugin:generate -DarchetypeGroupId=
 ## nablarch-batch
 
 ```
-mvn org.apache.maven.plugins:maven-archetype-plugin:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-batch-archetype -DarchetypeVersion=xxx
+mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-batch-archetype -DarchetypeVersion=xxx
 ```
 (xxxの箇所は、適切なバージョンを指定してください)
 
@@ -219,41 +219,41 @@ mvn org.apache.maven.plugins:maven-archetype-plugin:generate -DarchetypeGroupId=
 ## nablarch-batch-ee
 
 ```
-mvn org.apache.maven.plugins:maven-archetype-plugin:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-batch-ee-archetype -DarchetypeVersion=xxx
+mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-batch-ee-archetype -DarchetypeVersion=xxx
 ```
 (xxxの箇所は、適切なバージョンを指定してください)
 
 ## nablarch-batch-dbless
 
 ```
-mvn org.apache.maven.plugins:maven-archetype-plugin:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-batch-dbless-archetype -DarchetypeVersion=xxx
+mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-batch-dbless-archetype -DarchetypeVersion=xxx
 ```
 (xxxの箇所は、適切なバージョンを指定してください)
 
 ## nablarch-container-web
 
 ```
-mvn org.apache.maven.plugins:maven-archetype-plugin:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-web-archetype -DarchetypeVersion=xxx
+mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-web-archetype -DarchetypeVersion=xxx
 ```
 (xxxの箇所は、適切なバージョンを指定してください)
 
 ## nablarch-container-jaxrs
 
 ```
-mvn org.apache.maven.plugins:maven-archetype-plugin:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-jaxrs-archetype -DarchetypeVersion=xxx
+mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-jaxrs-archetype -DarchetypeVersion=xxx
 ```
 (xxxの箇所は、適切なバージョンを指定してください)
 
 ## nablarch-container-batch
 
 ```
-mvn org.apache.maven.plugins:maven-archetype-plugin:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-batch-archetype -DarchetypeVersion=xxx
+mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-batch-archetype -DarchetypeVersion=xxx
 ```
 (xxxの箇所は、適切なバージョンを指定してください)
 
 ## nablarch-container-batch-dbless
 
 ```
-mvn org.apache.maven.plugins:maven-archetype-plugin:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-batch-dbless-archetype -DarchetypeVersion=xxx
+mvn archetype:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-batch-dbless-archetype -DarchetypeVersion=xxx
 ```
 (xxxの箇所は、適切なバージョンを指定してください)

--- a/README.md
+++ b/README.md
@@ -3,25 +3,33 @@ nablarch-single-module-archetype
 
 # 概要
 
-アーキタイプ及び、アーキタイプが参照するparentです。
+ブランクプロジェクトを作成するためのアーキタイプの雛形および親プロジェクトが含まれています。
 
-本リポジトリには、single module構成のアーキタイプが複数格納されています。
+アーキタイプは、以下の手順で作成します。
+
+1. 雛形プロジェクトからアーキタイプの作成
+1. 作成されたアーキタイプのカスタマイズ
+1. アーキタイプのインストールまたはデプロイ
+
+本リポジトリにはアーキタイプ自体は含まれておらず、本リポジトリ内のファイルからアーキタイプを作成します。  
+また、single module構成のアーキタイプ向けのプロジェクトが複数格納されています。
 
 
 # 存在するモジュール
 
-| モジュール                           | 説明                                             |
-|:--------------------------------|:-----------------------------------------------|
-| nablarch-archetype-parent       | 各アーキタイプの共通的な設定を記述したpom.xml                     |
-| nablarch-web                    | ウェブアプリケーション用アーキタイプ。                            |
-| nablarch-jaxrs                  | RESTfulウェブサービス用アーキタイプ。                         |
-| nablarch-batch                  | Nablarchバッチアプリケーション用アーキタイプ。                    |
-| nablarch-batch-ee               | JSR352に準拠したバッチアプリケーション用アーキタイプ。                 |
-| nablarch-batch-dbelss           | Nablarchバッチ（DB接続無し）アプリケーション用アーキタイプ。            |
-| nablarch-container-web          | ウェブアプリケーションのDockerコンテナ用アーキタイプ。                 |
-| nablarch-container-jaxrs        | RESTfulウェブサービスのDockerコンテナ用アーキタイプ。              |
-| nablarch-container-batch        | NablarchバッチアプリケーションのDockerコンテナ用アーキタイプ。         |
-| nablarch-container-batch-dbless | Nablarchバッチ（DB接続無し）アプリケーションのDockerコンテナ用アーキタイプ。 |
+| モジュール                           | 説明                                                              |
+|:--------------------------------|:----------------------------------------------------------------|
+| nablarch-archetype-parent       | 各ひな形プロジェクトおよび各アーキタイプから生成されるプロジェクトの共通的な設定を記述したpom.xml。ブランクプロジェクトの親pom.xmlとなる。 |
+| nablarch-archetype-build-parent | 各アーキタイプの共通的な設定を記述したpom.xml。                                     |
+| nablarch-web                    | ウェブアプリケーション用アーキタイプの雛形プロジェクト。                                    |
+| nablarch-jaxrs                  | RESTfulウェブサービス用アーキタイプの雛形プロジェクト。                                 |
+| nablarch-batch                  | Nablarchバッチアプリケーション用アーキタイプの雛形プロジェクト。                            |
+| nablarch-batch-ee               | JSR352に準拠したバッチアプリケーション用アーキタイプの雛形プロジェクト。                         |
+| nablarch-batch-dbelss           | Nablarchバッチ（DB接続無し）アプリケーション用アーキタイプの雛形プロジェクト。                    |
+| nablarch-container-web          | ウェブアプリケーションのDockerコンテナ用アーキタイプの雛形プロジェクト。                         |
+| nablarch-container-jaxrs        | RESTfulウェブサービスのDockerコンテナ用アーキタイプの雛形プロジェクト。                      |
+| nablarch-container-batch        | NablarchバッチアプリケーションのDockerコンテナ用アーキタイプの雛形プロジェクト。                 |
+| nablarch-container-batch-dbless | Nablarchバッチ（DB接続無し）アプリケーションのDockerコンテナ用アーキタイプの雛形プロジェクト。         |
 
 
 # ビルド方法
@@ -35,12 +43,19 @@ cd nablarch-archetype-parent
 mvn install
 ```
 
+## nablarch-archetype-build-parent
+
+```
+cd nablarch-archetype-build-parent
+mvn install
+```
+
 ## nablarch-web
 
 ```
 # nablarch-webプロジェクトをベースにアーキタイプを生成
 pushd nablarch-web
-mvn clean archetype:2.4:create-from-project
+mvn clean archetype:create-from-project
 popd
 
 # 独自のカスタマイズを加える
@@ -55,7 +70,7 @@ mvn install
 ```
 # nablarch-jaxrsプロジェクトをベースにアーキタイプを生成
 pushd nablarch-jaxrs
-mvn clean archetype:2.4:create-from-project
+mvn clean archetype:create-from-project
 popd
 
 # 独自のカスタマイズを加える
@@ -70,7 +85,7 @@ mvn install
 ```
 # nablarch-batchプロジェクトをベースにアーキタイプを生成
 pushd nablarch-batch
-mvn clean archetype:2.4:create-from-project
+mvn clean archetype:create-from-project
 popd
 
 # 独自のカスタマイズを加える
@@ -85,7 +100,7 @@ mvn install
 ```
 # nablarch-batch-eeプロジェクトをベースにアーキタイプを生成
 pushd nablarch-batch-ee
-mvn clean archetype:2.4:create-from-project
+mvn clean archetype:create-from-project
 popd
 
 # 独自のカスタマイズを加える
@@ -100,7 +115,7 @@ mvn install
 ```
 # nablarch-batch-dblessプロジェクトをベースにアーキタイプを生成
 pushd nablarch-batch-dbless
-mvn clean archetype:2.4:create-from-project
+mvn clean archetype:create-from-project
 popd
 
 # 独自のカスタマイズを加える
@@ -115,7 +130,7 @@ mvn install
 ```
 # nablarch-container-webプロジェクトをベースにアーキタイプを生成
 pushd nablarch-container-web
-mvn clean archetype:2.4:create-from-project
+mvn clean archetype:create-from-project
 popd
 
 # 独自のカスタマイズを加える
@@ -130,7 +145,7 @@ mvn install
 ```
 # nablarch-container-jaxrsプロジェクトをベースにアーキタイプを生成
 pushd nablarch-container-jaxrs
-mvn clean archetype:2.4:create-from-project
+mvn clean archetype:create-from-project
 popd
 
 # 独自のカスタマイズを加える
@@ -145,7 +160,7 @@ mvn install
 ```
 # nablarch-container-batchプロジェクトをベースにアーキタイプを生成
 pushd nablarch-container-batch
-mvn clean archetype:2.4:create-from-project
+mvn clean archetype:create-from-project
 popd
 
 # 独自のカスタマイズを加える
@@ -160,7 +175,7 @@ mvn install
 ```
 # nablarch-container-batch-dblessプロジェクトをベースにアーキタイプを生成
 pushd nablarch-container-batch-dbless
-mvn clean archetype:2.4:create-from-project
+mvn clean archetype:create-from-project
 popd
 
 # 独自のカスタマイズを加える
@@ -180,7 +195,7 @@ mvn install
 ## nablarch-web
 
 ```
-mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion=xxx
+mvn org.apache.maven.plugins:maven-archetype-plugin:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-web-archetype -DarchetypeVersion=xxx
 ```
 (xxxの箇所は、適切なバージョンを指定してください)
 
@@ -188,7 +203,7 @@ mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGrou
 ## nablarch-jaxrs
 
 ```
-mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-jaxrs-archetype -DarchetypeVersion=xxx
+mvn org.apache.maven.plugins:maven-archetype-plugin:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-jaxrs-archetype -DarchetypeVersion=xxx
 ```
 (xxxの箇所は、適切なバージョンを指定してください)
 
@@ -196,7 +211,7 @@ mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGrou
 ## nablarch-batch
 
 ```
-mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-batch-archetype -DarchetypeVersion=xxx
+mvn org.apache.maven.plugins:maven-archetype-plugin:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-batch-archetype -DarchetypeVersion=xxx
 ```
 (xxxの箇所は、適切なバージョンを指定してください)
 
@@ -204,41 +219,41 @@ mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGrou
 ## nablarch-batch-ee
 
 ```
-mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-batch-ee-archetype -DarchetypeVersion=xxx
+mvn org.apache.maven.plugins:maven-archetype-plugin:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-batch-ee-archetype -DarchetypeVersion=xxx
 ```
 (xxxの箇所は、適切なバージョンを指定してください)
 
 ## nablarch-batch-dbless
 
 ```
-mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-batch-dbless-archetype -DarchetypeVersion=xxx
+mvn org.apache.maven.plugins:maven-archetype-plugin:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-batch-dbless-archetype -DarchetypeVersion=xxx
 ```
 (xxxの箇所は、適切なバージョンを指定してください)
 
 ## nablarch-container-web
 
 ```
-mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-web-archetype -DarchetypeVersion=xxx
+mvn org.apache.maven.plugins:maven-archetype-plugin:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-web-archetype -DarchetypeVersion=xxx
 ```
 (xxxの箇所は、適切なバージョンを指定してください)
 
 ## nablarch-container-jaxrs
 
 ```
-mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-jaxrs-archetype -DarchetypeVersion=xxx
+mvn org.apache.maven.plugins:maven-archetype-plugin:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-jaxrs-archetype -DarchetypeVersion=xxx
 ```
 (xxxの箇所は、適切なバージョンを指定してください)
 
 ## nablarch-container-batch
 
 ```
-mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-batch-archetype -DarchetypeVersion=xxx
+mvn org.apache.maven.plugins:maven-archetype-plugin:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-batch-archetype -DarchetypeVersion=xxx
 ```
 (xxxの箇所は、適切なバージョンを指定してください)
 
 ## nablarch-container-batch-dbless
 
 ```
-mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-batch-dbless-archetype -DarchetypeVersion=xxx
+mvn org.apache.maven.plugins:maven-archetype-plugin:generate -DarchetypeGroupId=com.nablarch.archetype -DarchetypeArtifactId=nablarch-container-batch-dbless-archetype -DarchetypeVersion=xxx
 ```
 (xxxの箇所は、適切なバージョンを指定してください)

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ mvn install
 
 # ビルドしたアーキタイプからプロジェクトを生成する方法
 
-## nablarch-archetype-parent
+## nablarch-archetype-parent, nablarch-archetype-build-parent
 
 アーキタイプでは無いため省略。
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ nablarch-single-module-archetype
 | モジュール                           | 説明                                                              |
 |:--------------------------------|:----------------------------------------------------------------|
 | nablarch-archetype-parent       | 各ひな形プロジェクトおよび各アーキタイプから生成されるプロジェクトの共通的な設定を記述したpom.xml。ブランクプロジェクトの親pom.xmlとなる。 |
-| nablarch-archetype-build-parent | 各アーキタイプの共通的な設定を記述したpom.xml。                                     |
+| nablarch-archetype-build-parent | 各アーキタイプの共通的な設定を記述したpom.xml。雛形プロジェクトから生成されたアーキタイプをカスタマイズした際に親pom.xmlとして設定される。                            |
 | nablarch-web                    | ウェブアプリケーション用アーキタイプの雛形プロジェクト。                                    |
 | nablarch-jaxrs                  | RESTfulウェブサービス用アーキタイプの雛形プロジェクト。                                 |
 | nablarch-batch                  | Nablarchバッチアプリケーション用アーキタイプの雛形プロジェクト。                            |

--- a/archetype-metadata-batch-ee.xml
+++ b/archetype-metadata-batch-ee.xml
@@ -9,8 +9,8 @@
         <include>**/*.java</include>
       </includes>
     </fileSet>
-    <fileSet packaged="true" encoding="UTF-8">
-      <directory>src/main/resources</directory>
+    <fileSet encoding="UTF-8">
+      <directory>src/main/resources/__packageInPathFormat__</directory>
       <includes>
         <include>**/*.sql</include>
       </includes>

--- a/nablarch-archetype-build-parent/pom.xml
+++ b/nablarch-archetype-build-parent/pom.xml
@@ -1,9 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
+  <!--
+   nablarch-archetype自体の親pom。
+   nablarch-archetypeをMaven Centralにデプロイするための設定を行う。
+
+   nablarch-archetypeは雛形になっているプロジェクトからarchetype:create-from-projectで
+   作成するが、その親pomはnablarch-archetype-parentに設定された状態で生成される。
+   Maven Centralへのデプロイ前に、parentをnablarch-archetype-parentから本pomに書き換えること。
+   （各種pre-create-maven-archetype-*.shで行う）
+  -->
+
   <groupId>com.nablarch.archetype</groupId>
-  <artifactId>archetype-build-parent</artifactId>
-  <version>1.0.0</version>
+  <artifactId>nablarch-archetype-build-parent</artifactId>
+  <version>6-NEXT-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <licenses>
@@ -34,6 +45,7 @@
     <version.plugins.source>3.3.1</version.plugins.source>
     <version.plugins.javadoc>3.10.0</version.plugins.javadoc>
     <version.plugins.gpg>3.2.5</version.plugins.gpg>
+    <version.plugins.archetype>3.2.1</version.plugins.archetype>
   </properties>
 
   <build>
@@ -77,6 +89,15 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-archetype-plugin</artifactId>
+        <version>${version.plugins.archetype}</version>
+        <configuration>
+          <!-- .gitignore等のファイルはデフォルトで除外されるので、これらを含めるための設定 -->
+          <useDefaultExcludes>false</useDefaultExcludes>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/nablarch-archetype-parent/pom.xml
+++ b/nablarch-archetype-parent/pom.xml
@@ -3,11 +3,12 @@
   <modelVersion>4.0.0</modelVersion>
 
   <!--
-    nablarch-archetypeの親pom。
+   nablarch-archetypeから生成されたブランクプロジェクトの親pom。
    プロジェクト非依存の設定を行う。
+    * Mavenプラグインや依存ライブラリのバージョン定義
     * Mavenプラグインの共通設定
 
-   生成されたarchetypeのparentは、このpomを親とする。
+   ブランクプロジェクトは、このpomをparentに設定した状態で生成される。
   -->
 
   <groupId>com.nablarch.archetype</groupId>

--- a/pre-create-maven-archetype-batch-dbless.sh
+++ b/pre-create-maven-archetype-batch-dbless.sh
@@ -6,7 +6,7 @@ BUILD_PARENT_GROUP_ID=com.nablarch.archetype
 BUILD_PARENT_ARTIFACT_ID=nablarch-archetype-build-parent
 BUILD_PARENT_VERSION=$(grep -E '^  <version>(.+)</version>$' ${SCRIPT_DIR}/nablarch-archetype-build-parent/pom.xml | sed -r 's|^  <version>(.+)</version>$|\1|')
 
-# コピーした親pomをarchetypのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomとなるように書き換える。
+# archetypeのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomをnablarch-archetype-build-parentとなるように書き換える。
 sed -iorig 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' ./nablarch-batch-dbless/target/generated-sources/archetype/pom.xml
 
 # .gitignoreを配置する

--- a/pre-create-maven-archetype-batch-dbless.sh
+++ b/pre-create-maven-archetype-batch-dbless.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
-# archetypeのOSSRHにデプロイで必要となるbuild処理を定義した親pomをコピーする。
-cp ./archetype-build-parent.xml ./nablarch-batch-dbless/target/generated-sources/archetype/
+SCRIPT_DIR=$(dirname $0)
+
+BUILD_PARENT_GROUP_ID=com.nablarch.archetype
+BUILD_PARENT_ARTIFACT_ID=nablarch-archetype-build-parent
+BUILD_PARENT_VERSION=$(grep -E '^  <version>(.+)</version>$' ${SCRIPT_DIR}/nablarch-archetype-build-parent/pom.xml | sed -r 's|^  <version>(.+)</version>$|\1|')
 
 # コピーした親pomをarchetypのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomとなるように書き換える。
-sed -iorig 's|/modelVersion>|/modelVersion>\n <parent>\n<groupId>com.nablarch.archetype</groupId>\n<artifactId>archetype-build-parent</artifactId>\n<version>1.0.0</version>\n<relativePath>archetype-build-parent.xml</relativePath>\n</parent>|' ./nablarch-batch-dbless/target/generated-sources/archetype/pom.xml
+sed -iorig 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' ./nablarch-batch-dbless/target/generated-sources/archetype/pom.xml
 
 # .gitignoreを配置する
 cp ./gitignore/.gitignore ./nablarch-batch-dbless/target/generated-sources/archetype/src/main/resources/archetype-resources
-
-# .gitignoreをアーキタイプに含めるため、maven-resources-pluginのコンフィグを明示的に設定する
-sed -i -e "s|</extensions>|</extensions>\n<plugins><plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-resources-plugin</artifactId><configuration><addDefaultExcludes>false</addDefaultExcludes></configuration></plugin></plugins>|" ./nablarch-batch-dbless/target/generated-sources/archetype/pom.xml
 
 # configファイルの置換文字列が機能するようにした設定をコピーする
 cp archetype-metadata-batch-dbless.xml ./nablarch-batch-dbless/target/generated-sources/archetype/src/main/resources/META-INF/maven/archetype-metadata.xml

--- a/pre-create-maven-archetype-batch-ee.sh
+++ b/pre-create-maven-archetype-batch-ee.sh
@@ -23,8 +23,6 @@ sed -i -e "s/com\/nablarch\/archetype/\${packageInPathFormat}/g" pom.xml
 sed -i -e "s/      <artifactId>\${rootArtifactId}<\/artifactId>/      <artifactId>nablarch-batch-ee<\/artifactId>/g" pom.xml
 # configファイル中のパッケージを置換文字列にする。
 sed -i -e "s/com\.nablarch\.archetype/\${package}/g" src/main/resources/*.properties
-# SQLファイルを移動。
-mv src/main/resources/com/nablarch/archetype/entity/*.sql src/main/resources/entity/
 # 想定箇所以外が${version}に置換されている可能性があるため、pom.xml以外の置換は元に戻す
 # `archetype_version` にはnablarch-archetype-parentのバージョンが入っているが、アーキタイプのバージョンと一致しているため問題ない。
 archetype_version=`grep -m 1 "<version>" pom.xml | awk -F '[><]' '{print $3}'`

--- a/pre-create-maven-archetype-batch-ee.sh
+++ b/pre-create-maven-archetype-batch-ee.sh
@@ -1,16 +1,17 @@
 #!/bin/bash
 
 # archetypeのOSSRHにデプロイで必要となるbuild処理を定義した親pomをコピーする。
-cp ./archetype-build-parent.xml ./nablarch-batch-ee/target/generated-sources/archetype/
+SCRIPT_DIR=$(dirname $0)
+
+BUILD_PARENT_GROUP_ID=com.nablarch.archetype
+BUILD_PARENT_ARTIFACT_ID=nablarch-archetype-build-parent
+BUILD_PARENT_VERSION=$(grep -E '^  <version>(.+)</version>$' ${SCRIPT_DIR}/nablarch-archetype-build-parent/pom.xml | sed -r 's|^  <version>(.+)</version>$|\1|')
 
 # コピーした親pomをarchetypのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomとなるように書き換える。
-sed -iorig 's|/modelVersion>|/modelVersion>\n <parent>\n<groupId>com.nablarch.archetype</groupId>\n<artifactId>archetype-build-parent</artifactId>\n<version>1.0.0</version>\n<relativePath>archetype-build-parent.xml</relativePath>\n</parent>|' ./nablarch-batch-ee/target/generated-sources/archetype/pom.xml
+sed -iorig 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' ./nablarch-batch-ee/target/generated-sources/archetype/pom.xml
 
 # .gitignoreを配置する
 cp ./gitignore/.gitignore ./nablarch-batch-ee/target/generated-sources/archetype/src/main/resources/archetype-resources
-
-# .gitignoreをアーキタイプに含めるため、maven-resources-pluginのコンフィグを明示的に設定する
-sed -i -e "s|</extensions>|</extensions>\n<plugins><plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-resources-plugin</artifactId><configuration><addDefaultExcludes>false</addDefaultExcludes></configuration></plugin></plugins>|" ./nablarch-batch-ee/target/generated-sources/archetype/pom.xml
 
 # configファイルの置換文字列が機能するようにした設定をコピーする
 cp archetype-metadata-batch-ee.xml ./nablarch-batch-ee/target/generated-sources/archetype/src/main/resources/META-INF/maven/archetype-metadata.xml

--- a/pre-create-maven-archetype-batch-ee.sh
+++ b/pre-create-maven-archetype-batch-ee.sh
@@ -7,7 +7,7 @@ BUILD_PARENT_GROUP_ID=com.nablarch.archetype
 BUILD_PARENT_ARTIFACT_ID=nablarch-archetype-build-parent
 BUILD_PARENT_VERSION=$(grep -E '^  <version>(.+)</version>$' ${SCRIPT_DIR}/nablarch-archetype-build-parent/pom.xml | sed -r 's|^  <version>(.+)</version>$|\1|')
 
-# コピーした親pomをarchetypのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomとなるように書き換える。
+# archetypeのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomをnablarch-archetype-build-parentとなるように書き換える。
 sed -iorig 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' ./nablarch-batch-ee/target/generated-sources/archetype/pom.xml
 
 # .gitignoreを配置する

--- a/pre-create-maven-archetype-batch.sh
+++ b/pre-create-maven-archetype-batch.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
-# archetypeのOSSRHにデプロイで必要となるbuild処理を定義した親pomをコピーする。
-cp ./archetype-build-parent.xml ./nablarch-batch/target/generated-sources/archetype/
+SCRIPT_DIR=$(dirname $0)
+
+BUILD_PARENT_GROUP_ID=com.nablarch.archetype
+BUILD_PARENT_ARTIFACT_ID=nablarch-archetype-build-parent
+BUILD_PARENT_VERSION=$(grep -E '^  <version>(.+)</version>$' ${SCRIPT_DIR}/nablarch-archetype-build-parent/pom.xml | sed -r 's|^  <version>(.+)</version>$|\1|')
 
 # コピーした親pomをarchetypのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomとなるように書き換える。
-sed -iorig 's|/modelVersion>|/modelVersion>\n <parent>\n<groupId>com.nablarch.archetype</groupId>\n<artifactId>archetype-build-parent</artifactId>\n<version>1.0.0</version>\n<relativePath>archetype-build-parent.xml</relativePath>\n</parent>|' ./nablarch-batch/target/generated-sources/archetype/pom.xml
+sed -iorig 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' ./nablarch-batch/target/generated-sources/archetype/pom.xml
 
 # .gitignoreを配置する
 cp ./gitignore/.gitignore ./nablarch-batch/target/generated-sources/archetype/src/main/resources/archetype-resources
-
-# .gitignoreをアーキタイプに含めるため、maven-resources-pluginのコンフィグを明示的に設定する
-sed -i -e "s|</extensions>|</extensions>\n<plugins><plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-resources-plugin</artifactId><configuration><addDefaultExcludes>false</addDefaultExcludes></configuration></plugin></plugins>|" ./nablarch-batch/target/generated-sources/archetype/pom.xml
 
 # configファイルの置換文字列が機能するようにした設定をコピーする
 cp archetype-metadata-batch.xml ./nablarch-batch/target/generated-sources/archetype/src/main/resources/META-INF/maven/archetype-metadata.xml

--- a/pre-create-maven-archetype-batch.sh
+++ b/pre-create-maven-archetype-batch.sh
@@ -6,7 +6,7 @@ BUILD_PARENT_GROUP_ID=com.nablarch.archetype
 BUILD_PARENT_ARTIFACT_ID=nablarch-archetype-build-parent
 BUILD_PARENT_VERSION=$(grep -E '^  <version>(.+)</version>$' ${SCRIPT_DIR}/nablarch-archetype-build-parent/pom.xml | sed -r 's|^  <version>(.+)</version>$|\1|')
 
-# コピーした親pomをarchetypのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomとなるように書き換える。
+# archetypeのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomをnablarch-archetype-build-parentとなるように書き換える。
 sed -iorig 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' ./nablarch-batch/target/generated-sources/archetype/pom.xml
 
 # .gitignoreを配置する

--- a/pre-create-maven-archetype-container-batch-dbless.sh
+++ b/pre-create-maven-archetype-container-batch-dbless.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
-# archetypeのOSSRHにデプロイで必要となるbuild処理を定義した親pomをコピーする。
-cp ./archetype-build-parent.xml ./nablarch-container-batch-dbless/target/generated-sources/archetype/
+SCRIPT_DIR=$(dirname $0)
+
+BUILD_PARENT_GROUP_ID=com.nablarch.archetype
+BUILD_PARENT_ARTIFACT_ID=nablarch-archetype-build-parent
+BUILD_PARENT_VERSION=$(grep -E '^  <version>(.+)</version>$' ${SCRIPT_DIR}/nablarch-archetype-build-parent/pom.xml | sed -r 's|^  <version>(.+)</version>$|\1|')
 
 # コピーした親pomをarchetypのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomとなるように書き換える。
-sed -iorig 's|/modelVersion>|/modelVersion>\n <parent>\n<groupId>com.nablarch.archetype</groupId>\n<artifactId>archetype-build-parent</artifactId>\n<version>1.0.0</version>\n<relativePath>archetype-build-parent.xml</relativePath>\n</parent>|' ./nablarch-container-batch-dbless/target/generated-sources/archetype/pom.xml
+sed -iorig 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' ./nablarch-container-batch-dbless/target/generated-sources/archetype/pom.xml
 
 # .gitignoreを配置する
 cp ./gitignore/.gitignore ./nablarch-container-batch-dbless/target/generated-sources/archetype/src/main/resources/archetype-resources
-
-# .gitignoreをアーキタイプに含めるため、maven-resources-pluginのコンフィグを明示的に設定する
-sed -i -e "s|</extensions>|</extensions>\n<plugins><plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-resources-plugin</artifactId><configuration><addDefaultExcludes>false</addDefaultExcludes></configuration></plugin></plugins>|" ./nablarch-container-batch-dbless/target/generated-sources/archetype/pom.xml
 
 # configファイルの置換文字列が機能するようにした設定をコピーする
 cp archetype-metadata-container-batch-dbless.xml ./nablarch-container-batch-dbless/target/generated-sources/archetype/src/main/resources/META-INF/maven/archetype-metadata.xml

--- a/pre-create-maven-archetype-container-batch-dbless.sh
+++ b/pre-create-maven-archetype-container-batch-dbless.sh
@@ -6,7 +6,7 @@ BUILD_PARENT_GROUP_ID=com.nablarch.archetype
 BUILD_PARENT_ARTIFACT_ID=nablarch-archetype-build-parent
 BUILD_PARENT_VERSION=$(grep -E '^  <version>(.+)</version>$' ${SCRIPT_DIR}/nablarch-archetype-build-parent/pom.xml | sed -r 's|^  <version>(.+)</version>$|\1|')
 
-# コピーした親pomをarchetypのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomとなるように書き換える。
+# archetypeのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomをnablarch-archetype-build-parentとなるように書き換える。
 sed -iorig 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' ./nablarch-container-batch-dbless/target/generated-sources/archetype/pom.xml
 
 # .gitignoreを配置する

--- a/pre-create-maven-archetype-container-batch.sh
+++ b/pre-create-maven-archetype-container-batch.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
-# archetypeのOSSRHにデプロイで必要となるbuild処理を定義した親pomをコピーする。
-cp ./archetype-build-parent.xml ./nablarch-container-batch/target/generated-sources/archetype/
+SCRIPT_DIR=$(dirname $0)
+
+BUILD_PARENT_GROUP_ID=com.nablarch.archetype
+BUILD_PARENT_ARTIFACT_ID=nablarch-archetype-build-parent
+BUILD_PARENT_VERSION=$(grep -E '^  <version>(.+)</version>$' ${SCRIPT_DIR}/nablarch-archetype-build-parent/pom.xml | sed -r 's|^  <version>(.+)</version>$|\1|')
 
 # コピーした親pomをarchetypのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomとなるように書き換える。
-sed -iorig 's|/modelVersion>|/modelVersion>\n <parent>\n<groupId>com.nablarch.archetype</groupId>\n<artifactId>archetype-build-parent</artifactId>\n<version>1.0.0</version>\n<relativePath>archetype-build-parent.xml</relativePath>\n</parent>|' ./nablarch-container-batch/target/generated-sources/archetype/pom.xml
+sed -iorig 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' ./nablarch-container-batch/target/generated-sources/archetype/pom.xml
 
 # .gitignoreを配置する
 cp ./gitignore/.gitignore ./nablarch-container-batch/target/generated-sources/archetype/src/main/resources/archetype-resources
-
-# .gitignoreをアーキタイプに含めるため、maven-resources-pluginのコンフィグを明示的に設定する
-sed -i -e "s|</extensions>|</extensions>\n<plugins><plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-resources-plugin</artifactId><configuration><addDefaultExcludes>false</addDefaultExcludes></configuration></plugin></plugins>|" ./nablarch-container-batch/target/generated-sources/archetype/pom.xml
 
 # configファイルの置換文字列が機能するようにした設定をコピーする
 cp archetype-metadata-container-batch.xml ./nablarch-container-batch/target/generated-sources/archetype/src/main/resources/META-INF/maven/archetype-metadata.xml

--- a/pre-create-maven-archetype-container-batch.sh
+++ b/pre-create-maven-archetype-container-batch.sh
@@ -6,7 +6,7 @@ BUILD_PARENT_GROUP_ID=com.nablarch.archetype
 BUILD_PARENT_ARTIFACT_ID=nablarch-archetype-build-parent
 BUILD_PARENT_VERSION=$(grep -E '^  <version>(.+)</version>$' ${SCRIPT_DIR}/nablarch-archetype-build-parent/pom.xml | sed -r 's|^  <version>(.+)</version>$|\1|')
 
-# コピーした親pomをarchetypのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomとなるように書き換える。
+# archetypeのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomをnablarch-archetype-build-parentとなるように書き換える。
 sed -iorig 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' ./nablarch-container-batch/target/generated-sources/archetype/pom.xml
 
 # .gitignoreを配置する

--- a/pre-create-maven-archetype-container-jaxrs.sh
+++ b/pre-create-maven-archetype-container-jaxrs.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
-# archetypeのOSSRHにデプロイで必要となるbuild処理を定義した親pomをコピーする。
-cp ./archetype-build-parent.xml ./nablarch-container-jaxrs/target/generated-sources/archetype/
- 
+SCRIPT_DIR=$(dirname $0)
+
+BUILD_PARENT_GROUP_ID=com.nablarch.archetype
+BUILD_PARENT_ARTIFACT_ID=nablarch-archetype-build-parent
+BUILD_PARENT_VERSION=$(grep -E '^  <version>(.+)</version>$' ${SCRIPT_DIR}/nablarch-archetype-build-parent/pom.xml | sed -r 's|^  <version>(.+)</version>$|\1|')
+
 # コピーした親pomをarchetypのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomとなるように書き換える。
- sed -iorig 's|/modelVersion>|/modelVersion>\n <parent>\n<groupId>com.nablarch.archetype</groupId>\n<artifactId>archetype-build-parent</artifactId>\n<version>1.0.0</version>\n<relativePath>archetype-build-parent.xml</relativePath>\n</parent>|' ./nablarch-container-jaxrs/target/generated-sources/archetype/pom.xml
+sed -iorig 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' ./nablarch-container-jaxrs/target/generated-sources/archetype/pom.xml
 
 # .gitignoreを配置する
 cp ./gitignore/.gitignore ./nablarch-container-jaxrs/target/generated-sources/archetype/src/main/resources/archetype-resources

--- a/pre-create-maven-archetype-container-jaxrs.sh
+++ b/pre-create-maven-archetype-container-jaxrs.sh
@@ -6,14 +6,11 @@ BUILD_PARENT_GROUP_ID=com.nablarch.archetype
 BUILD_PARENT_ARTIFACT_ID=nablarch-archetype-build-parent
 BUILD_PARENT_VERSION=$(grep -E '^  <version>(.+)</version>$' ${SCRIPT_DIR}/nablarch-archetype-build-parent/pom.xml | sed -r 's|^  <version>(.+)</version>$|\1|')
 
-# コピーした親pomをarchetypのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomとなるように書き換える。
+# archetypeのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomをnablarch-archetype-build-parentとなるように書き換える。
 sed -iorig 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' ./nablarch-container-jaxrs/target/generated-sources/archetype/pom.xml
 
 # .gitignoreを配置する
 cp ./gitignore/.gitignore ./nablarch-container-jaxrs/target/generated-sources/archetype/src/main/resources/archetype-resources
-
-# .gitignoreをアーキタイプに含めるため、maven-resources-pluginのコンフィグを明示的に設定する
-sed -i -e "s|</extensions>|</extensions>\n<plugins><plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-resources-plugin</artifactId><configuration><addDefaultExcludes>false</addDefaultExcludes></configuration></plugin></plugins>|" ./nablarch-container-jaxrs/target/generated-sources/archetype/pom.xml
 
 # configファイルの置換文字列が機能するようにした設定をコピーする
 cp archetype-metadata-container-jaxrs.xml ./nablarch-container-jaxrs/target/generated-sources/archetype/src/main/resources/META-INF/maven/archetype-metadata.xml

--- a/pre-create-maven-archetype-container-web.sh
+++ b/pre-create-maven-archetype-container-web.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
-# archetypeのOSSRHにデプロイで必要となるbuild処理を定義した親pomをコピーする。
-cp ./archetype-build-parent.xml ./nablarch-container-web/target/generated-sources/archetype/
+SCRIPT_DIR=$(dirname $0)
+
+BUILD_PARENT_GROUP_ID=com.nablarch.archetype
+BUILD_PARENT_ARTIFACT_ID=nablarch-archetype-build-parent
+BUILD_PARENT_VERSION=$(grep -E '^  <version>(.+)</version>$' ${SCRIPT_DIR}/nablarch-archetype-build-parent/pom.xml | sed -r 's|^  <version>(.+)</version>$|\1|')
 
 # コピーした親pomをarchetypのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomとなるように書き換える。
-sed -iorig 's|/modelVersion>|/modelVersion>\n <parent>\n<groupId>com.nablarch.archetype</groupId>\n<artifactId>archetype-build-parent</artifactId>\n<version>1.0.0</version>\n<relativePath>archetype-build-parent.xml</relativePath>\n</parent>|' ./nablarch-container-web/target/generated-sources/archetype/pom.xml
+sed -iorig 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' ./nablarch-container-web/target/generated-sources/archetype/pom.xml
 
 # .gitignoreを配置する
 cp ./gitignore/.gitignore ./nablarch-container-web/target/generated-sources/archetype/src/main/resources/archetype-resources
-
-# .gitignoreをアーキタイプに含めるため、maven-resources-pluginのコンフィグを明示的に設定する
-sed -i -e "s|</extensions>|</extensions>\n<plugins><plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-resources-plugin</artifactId><configuration><addDefaultExcludes>false</addDefaultExcludes></configuration></plugin></plugins>|" ./nablarch-container-web/target/generated-sources/archetype/pom.xml
 
 # configファイルの置換文字列が機能するようにした設定をコピーする
 cp archetype-metadata-container-web.xml ./nablarch-container-web/target/generated-sources/archetype/src/main/resources/META-INF/maven/archetype-metadata.xml

--- a/pre-create-maven-archetype-container-web.sh
+++ b/pre-create-maven-archetype-container-web.sh
@@ -6,7 +6,7 @@ BUILD_PARENT_GROUP_ID=com.nablarch.archetype
 BUILD_PARENT_ARTIFACT_ID=nablarch-archetype-build-parent
 BUILD_PARENT_VERSION=$(grep -E '^  <version>(.+)</version>$' ${SCRIPT_DIR}/nablarch-archetype-build-parent/pom.xml | sed -r 's|^  <version>(.+)</version>$|\1|')
 
-# コピーした親pomをarchetypのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomとなるように書き換える。
+# archetypeのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomをnablarch-archetype-build-parentとなるように書き換える。
 sed -iorig 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' ./nablarch-container-web/target/generated-sources/archetype/pom.xml
 
 # .gitignoreを配置する

--- a/pre-create-maven-archetype-jaxrs.sh
+++ b/pre-create-maven-archetype-jaxrs.sh
@@ -6,7 +6,7 @@ BUILD_PARENT_GROUP_ID=com.nablarch.archetype
 BUILD_PARENT_ARTIFACT_ID=nablarch-archetype-build-parent
 BUILD_PARENT_VERSION=$(grep -E '^  <version>(.+)</version>$' ${SCRIPT_DIR}/nablarch-archetype-build-parent/pom.xml | sed -r 's|^  <version>(.+)</version>$|\1|')
  
-# コピーした親pomをarchetypのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomとなるように書き換える。
+# archetypeのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomをnablarch-archetype-build-parentとなるように書き換える。
 sed -iorig 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' ./nablarch-jaxrs/target/generated-sources/archetype/pom.xml
 
 # .gitignoreを配置する

--- a/pre-create-maven-archetype-jaxrs.sh
+++ b/pre-create-maven-archetype-jaxrs.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
-# archetypeのOSSRHにデプロイで必要となるbuild処理を定義した親pomをコピーする。
-cp ./archetype-build-parent.xml ./nablarch-jaxrs/target/generated-sources/archetype/
+SCRIPT_DIR=$(dirname $0)
+
+BUILD_PARENT_GROUP_ID=com.nablarch.archetype
+BUILD_PARENT_ARTIFACT_ID=nablarch-archetype-build-parent
+BUILD_PARENT_VERSION=$(grep -E '^  <version>(.+)</version>$' ${SCRIPT_DIR}/nablarch-archetype-build-parent/pom.xml | sed -r 's|^  <version>(.+)</version>$|\1|')
  
 # コピーした親pomをarchetypのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomとなるように書き換える。
- sed -iorig 's|/modelVersion>|/modelVersion>\n <parent>\n<groupId>com.nablarch.archetype</groupId>\n<artifactId>archetype-build-parent</artifactId>\n<version>1.0.0</version>\n<relativePath>archetype-build-parent.xml</relativePath>\n</parent>|' ./nablarch-jaxrs/target/generated-sources/archetype/pom.xml
+sed -iorig 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' ./nablarch-jaxrs/target/generated-sources/archetype/pom.xml
 
 # .gitignoreを配置する
 cp ./gitignore/.gitignore ./nablarch-jaxrs/target/generated-sources/archetype/src/main/resources/archetype-resources
-
-# .gitignoreをアーキタイプに含めるため、maven-resources-pluginのコンフィグを明示的に設定する
-sed -i -e "s|</extensions>|</extensions>\n<plugins><plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-resources-plugin</artifactId><configuration><addDefaultExcludes>false</addDefaultExcludes></configuration></plugin></plugins>|" ./nablarch-jaxrs/target/generated-sources/archetype/pom.xml
 
 # configファイルの置換文字列が機能するようにした設定をコピーする
 cp archetype-metadata-jaxrs.xml ./nablarch-jaxrs/target/generated-sources/archetype/src/main/resources/META-INF/maven/archetype-metadata.xml

--- a/pre-create-maven-archetype-web.sh
+++ b/pre-create-maven-archetype-web.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
-# archetypeのOSSRHにデプロイで必要となるbuild処理を定義した親pomをコピーする。
-cp ./archetype-build-parent.xml ./nablarch-web/target/generated-sources/archetype/
+SCRIPT_DIR=$(dirname $0)
+
+BUILD_PARENT_GROUP_ID=com.nablarch.archetype
+BUILD_PARENT_ARTIFACT_ID=nablarch-archetype-build-parent
+BUILD_PARENT_VERSION=$(grep -E '^  <version>(.+)</version>$' ${SCRIPT_DIR}/nablarch-archetype-build-parent/pom.xml | sed -r 's|^  <version>(.+)</version>$|\1|')
 
 # コピーした親pomをarchetypのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomとなるように書き換える。
-sed -iorig 's|/modelVersion>|/modelVersion>\n <parent>\n<groupId>com.nablarch.archetype</groupId>\n<artifactId>archetype-build-parent</artifactId>\n<version>1.0.0</version>\n<relativePath>archetype-build-parent.xml</relativePath>\n</parent>|' ./nablarch-web/target/generated-sources/archetype/pom.xml
+sed -iorig 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' ./nablarch-web/target/generated-sources/archetype/pom.xml
 
 # .gitignoreを配置する
 cp ./gitignore/.gitignore ./nablarch-web/target/generated-sources/archetype/src/main/resources/archetype-resources
-
-# .gitignoreをアーキタイプに含めるため、maven-resources-pluginのコンフィグを明示的に設定する
-sed -i -e "s|</extensions>|</extensions>\n<plugins><plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-resources-plugin</artifactId><configuration><addDefaultExcludes>false</addDefaultExcludes></configuration></plugin></plugins>|" ./nablarch-web/target/generated-sources/archetype/pom.xml
 
 # configファイルの置換文字列が機能するようにした設定をコピーする
 cp archetype-metadata-web.xml ./nablarch-web/target/generated-sources/archetype/src/main/resources/META-INF/maven/archetype-metadata.xml

--- a/pre-create-maven-archetype-web.sh
+++ b/pre-create-maven-archetype-web.sh
@@ -6,7 +6,7 @@ BUILD_PARENT_GROUP_ID=com.nablarch.archetype
 BUILD_PARENT_ARTIFACT_ID=nablarch-archetype-build-parent
 BUILD_PARENT_VERSION=$(grep -E '^  <version>(.+)</version>$' ${SCRIPT_DIR}/nablarch-archetype-build-parent/pom.xml | sed -r 's|^  <version>(.+)</version>$|\1|')
 
-# コピーした親pomをarchetypのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomとなるように書き換える。
+# archetypeのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomをnablarch-archetype-build-parentとなるように書き換える。
 sed -iorig 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' ./nablarch-web/target/generated-sources/archetype/pom.xml
 
 # .gitignoreを配置する


### PR DESCRIPTION
# 概要

Maven Archetype Plugin 3.xでアーキタイプが生成できるように修正する。

- `archetype-build-parent.xml`をMavenプロジェクトとして管理（nablarch-archetype-build-parentにしました）
- `archetype-build-parent.xml`にMaven Archetype Pluginを追加し、3.2.1で登録
- カスタマイズスクリプトを修正
- 作業手順を最新化し、`README.md`に反映

nablarch-batch-eeについては、`src/main/resources`に含まれるパッケージ名をディレクトリするパターンの挙動が変わっていたので、`__packageInPathFormat__`を使うように修正。

3.x以降で不整合を起こしていた経緯は以下。

- `archetype:create-from-project`の時点で、`src/main/resources/__packageInPathFormat__/entity/SampleUser.sql`という出力なっていた
  - 2.xではこうなっていなかった模様
- ここにmetadataの`fileSet`要素の`packaged`属性が`true`になっていたことで、パッケージ名（からパスに変換したもの）が二重になっていた

# 確認

- nablarch-web
  - [x] ブランクプロジェクトが作成できること
  - [x] 生成されたブランクプロジェクトに.gitignoreが含まれていること
  - [x] `mvn clean package`が実行できること（基本的なビルドプロセスを実行し、多くのプラグインをカバーできていること）
  - [x] `mvn jetty:run`が実行でき、疎通確認ページが参照できること
  - [x] `mvn jacoco:report`が実行でき、カバレッジレポートを確認できること
  - [x] `mvn verify -DskipTests=true`が実行でき、JSP静的解析ツールが実行できること
  - [x] `mvn spotbugs:check`が実行でき、SpotBugsが実行できること
  - [x] `mvn release:help install:help deploy:help`が実行できること（Maven Release Plugin、Maven Install Plugin、Maven Deploy Pluginのバージョン指定に誤りがないことを確認）
- nablarch-jaxrs
  - [x] ブランクプロジェクトが作成できること
  - [x] 生成されたブランクプロジェクトに.gitignoreが含まれていること
  - [x] `mvn clean package`が実行できること（基本的なビルドプロセスを実行し、多くのプラグインをカバーできていること）
  - [x] `mvn jetty:run`が実行でき、疎通確認用のAPIが呼び出せること
  - [x] `mvn jacoco:report`が実行でき、カバレッジレポートを確認できること
  - [x] `mvn spotbugs:check`が実行でき、SpotBugsが実行できること
  - [x] `mvn release:help install:help deploy:help`が実行できること（Maven Release Plugin、Maven Install Plugin、Maven Deploy Pluginのバージョン指定に誤りがないことを確認）
- nablarch-batch
  - [x] ブランクプロジェクトが作成できること
  - [x] 生成されたブランクプロジェクトに.gitignoreが含まれていること
  - [x] `mvn clean install`が実行できること（基本的なビルドプロセスを実行し、多くのプラグインをカバーできていること）
  - [x] `mvn exec:java`が実行でき、起動テストができること
  - [x] `mvn jacoco:report`が実行でき、カバレッジレポートを確認できること
  - [x] `mvn spotbugs:check`が実行でき、SpotBugsが実行できること
  - [x] `mvn release:help install:help deploy:help`が実行できること（Maven Release Plugin、Maven Install Plugin、Maven Deploy Pluginのバージョン指定に誤りがないことを確認）
- nablarch-batch-ee
  - [x] ブランクプロジェクトが作成できること
  - [x] 生成されたブランクプロジェクトに.gitignoreが含まれていること
  - [x] `mvn clean install`が実行できること（基本的なビルドプロセスを実行し、多くのプラグインをカバーできていること）
  - [x] `mvn exec:java`が実行でき、起動テストができること
  - [x] `mvn jacoco:report`が実行でき、カバレッジレポートを確認できること
  - [x] `mvn spotbugs:check`が実行でき、SpotBugsが実行できること
  - [x] `mvn release:help install:help deploy:help`が実行できること（Maven Release Plugin、Maven Install Plugin、Maven Deploy Pluginのバージョン指定に誤りがないことを確認）
- nablarch-batch-dbless
  - [x] ブランクプロジェクトが作成できること
  - [x] 生成されたブランクプロジェクトに.gitignoreが含まれていること
  - [x] `mvn clean install`が実行できること（基本的なビルドプロセスを実行し、多くのプラグインをカバーできていること）
  - [x] `mvn exec:java`が実行でき、起動テストができること
  - [x] `mvn jacoco:report`が実行でき、カバレッジレポートを確認できること
  - [x] `mvn spotbugs:check`が実行でき、SpotBugsが実行できること
  - [x] `mvn release:help install:help deploy:help`が実行できること（Maven Release Plugin、Maven Install Plugin、Maven Deploy Pluginのバージョン指定に誤りがないことを確認）
- nablarch-container-web
  - [x] ブランクプロジェクトが作成できること
  - [x] 生成されたブランクプロジェクトに.gitignoreが含まれていること
  - [x] `mvn clean package jib:dockerBuild`が実行できること（基本的なビルドプロセスを実行し、多くのプラグインをカバーできていること、Dockerイメージが作成できること）
  - [x] `mvn jetty:run`が実行でき、疎通確認ページが参照できること
  - [x] `docker container run`で作成したコンテナを実行でき、疎通確認ができること
  - [x] `mvn jacoco:report`が実行でき、カバレッジレポートを確認できること
  - [x] `mvn verify -DskipTests=true`が実行でき、JSP静的解析ツールが実行できること
  - [x] `mvn spotbugs:check`が実行でき、SpotBugsが実行できること
  - [x] `mvn release:help install:help deploy:help`が実行できること（Maven Release Plugin、Maven Install Plugin、Maven Deploy Pluginのバージョン指定に誤りがないことを確認）
- nablarch-container-jaxrs
  - [x] ブランクプロジェクトが作成できること
  - [x] 生成されたブランクプロジェクトに.gitignoreが含まれていること
  - [x] `mvn clean package jib:dockerBuild`が実行できること（基本的なビルドプロセスを実行し、多くのプラグインをカバーできていること、Dockerイメージが作成できること）
  - [x] `mvn jetty:run`が実行でき、疎通確認ページが参照できること
  - [x] `docker container run`で作成したコンテナを実行でき、疎通確認ができること
  - [x] `mvn jacoco:report`が実行でき、カバレッジレポートを確認できること
  - [x] `mvn spotbugs:check`が実行でき、SpotBugsが実行できること
  - [x] `mvn release:help install:help deploy:help`が実行できること（Maven Release Plugin、Maven Install Plugin、Maven Deploy Pluginのバージョン指定に誤りがないことを確認）
- nablarch-container-batch
  - [x] ブランクプロジェクトが作成できること
  - [x] 生成されたブランクプロジェクトに.gitignoreが含まれていること
  - [x] `mvn clean package jib:dockerBuild`が実行できること（基本的なビルドプロセスを実行し、多くのプラグインをカバーできていること、Dockerイメージが作成できること）
  - [x] `mvn exec:java`が実行でき、起動テストができること
  - [x] `docker container run`で作成したコンテナを実行でき、疎通確認ができること
  - [x] `mvn jacoco:report`が実行でき、カバレッジレポートを確認できること
  - [x] `mvn spotbugs:check`が実行でき、SpotBugsが実行できること
  - [x] `mvn release:help install:help deploy:help`が実行できること（Maven Release Plugin、Maven Install Plugin、Maven Deploy Pluginのバージョン指定に誤りがないことを確認）
- nablarch-container-batch-dbless
  - [x] ブランクプロジェクトが作成できること
  - [x] 生成されたブランクプロジェクトに.gitignoreが含まれていること
  - [x] `mvn clean package jib:dockerBuild`が実行できること（基本的なビルドプロセスを実行し、多くのプラグインをカバーできていること、Dockerイメージが作成できること）
  - [x] `mvn exec:java`が実行でき、起動テストができること
  - [x] `docker container run`で作成したコンテナを実行でき、疎通確認ができること
  - [x] `mvn jacoco:report`が実行でき、カバレッジレポートを確認できること
  - [x] `mvn spotbugs:check`が実行でき、SpotBugsが実行できること
  - [x] `mvn release:help install:help deploy:help`が実行できること（Maven Release Plugin、Maven Install Plugin、Maven Deploy Pluginのバージョン指定に誤りがないことを確認）