### PR TITLE
リリースに関するプラグイン設定をossrh profileに移動

### DIFF
--- a/nablarch-archetype-build-parent/pom.xml
+++ b/nablarch-archetype-build-parent/pom.xml
@@ -51,6 +51,16 @@
   <profiles>
     <profile>
       <id>ossrh</id>
+      <distributionManagement>
+        <repository>
+          <id>nablarch.staging</id>
+          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+        </repository>
+        <snapshotRepository>
+          <id>nablarch.snapshot</id>
+          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+      </distributionManagement>
       <build>
         <plugins>
           <plugin>

--- a/nablarch-archetype-build-parent/pom.xml
+++ b/nablarch-archetype-build-parent/pom.xml
@@ -48,48 +48,58 @@
     <version.plugins.archetype>3.2.1</version.plugins.archetype>
   </properties>
 
+  <profiles>
+    <profile>
+      <id>ossrh</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>${version.plugins.source}</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>${version.plugins.javadoc}</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>${version.plugins.gpg}</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-        <version>${version.plugins.source}</version>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <goals>
-              <goal>jar-no-fork</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${version.plugins.javadoc}</version>
-        <executions>
-          <execution>
-            <id>attach-javadocs</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <version>${version.plugins.gpg}</version>
-        <executions>
-          <execution>
-            <id>sign-artifacts</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>sign</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-archetype-plugin</artifactId>


### PR DESCRIPTION
# 概要

Concourse CIでデプロイする時に`mvn install`でgpgを使用しようとして失敗したため、リリースに関するMavenプラグインをossrh profileに移動してossrh profileを有効にしない限りは実行されないように修正。

```shell
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-gpg-plugin:3.2.5:sign (sign-artifacts) on project nablarch-archetype-build-parent: failed to execute gpg: Error while executing process. Cannot run program "gpg": error=2, そのようなファイルやディレクトリはありません -> [Help 1]
```

Concourse CIでの`mvn install`時に`-Dgpg.skip=true`としても回避できるが、この修正方針とした理由は以下。

- 他のMavenアーティファクトとの統一性（Mavenデプロイまわりはossrh profileになっていることが多いため足並みを揃えた形）
  - #175 で削除した`nablarch-archetype-parent`のossrh profileを`nablarch-archetype-build-parent`に移したものになる
  - CIジョブ上でossrh profileを指定していないので効果はありませんが、`distributionManagement`も戻しました
- nablarch-archetype-parentとCIパイプライン上での不必要な差異を生む

Maven Archetype Pluginは通常時に使うので、profileの外に置いたままです。

# 確認

代表してnablarch-webアーキタイプを作成し、ブランクプロジェクトの作成、`.gitignore`が存在すること、テスト、パッケージングなどが可能なことを確認。