### PR TITLE
nablarch-archetype-parentにossrh profileを復元

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ nablarch-single-module-archetype
 
 # ビルド方法
 
-※GPGを使用しない環境で下記を実行する場合は、mvnコマンドに ``-Dgpg.skip=true`` を付加して実行すること。
-
 ## nablarch-archetype-parent
 
 ```

--- a/nablarch-archetype-parent/pom.xml
+++ b/nablarch-archetype-parent/pom.xml
@@ -41,6 +41,7 @@
     <version.plugins.javadoc>3.10.0</version.plugins.javadoc>
     <version.plugins.resources>3.3.1</version.plugins.resources>
     <version.plugins.source>3.3.1</version.plugins.source>
+    <version.plugins.gpg>3.2.5</version.plugins.gpg>
     <version.plugins.jacoco>0.8.12</version.plugins.jacoco>
     <version.plugins.build-helper-maven>3.6.0</version.plugins.build-helper-maven>
     <version.plugins.jib>3.4.3</version.plugins.jib>
@@ -406,4 +407,64 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>ossrh</id>
+      <distributionManagement>
+        <repository>
+          <id>nablarch.staging</id>
+          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+        </repository>
+        <snapshotRepository>
+          <id>nablarch.snapshot</id>
+          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+      </distributionManagement>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>${version.plugins.source}</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>${version.plugins.javadoc}</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>${version.plugins.gpg}</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Maven Centralへのデプロイ時に問題になることがわかったため、`nablarch-archetype-parent`にossrh profileを復元しました。  
またgpgはossrhを明示的に指定しない限り有効にならないのため、`README.md`からgpgのスキップに関する補足を削除しました。

復元したossrs profileは設定しているプラグインが通常設定と重複（javadoc、source）していますが、他の`pom.xml`のossrh profileと異なる記述にするのも足並みが揃わないと、利用者から見てもossrh profileを有効にしなければ関係のない設定のため以前と同じ記述のまま復元しました。

動作確認。

- [x] ossrh profileを追加して`mvn install`し、アーキタイプが作成できること
- [x] アーキタイプから作成したプロジェクトが動作すること
- [x] アーキタイプから作成したプロジェクトで、`mvn help:all-profiles`でossrh profileが出現すること