### PR TITLE
nablarch-archetype-parentにossrh profileを復元（v5）

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ nablarch-single-module-archetype
 
 # ビルド方法
 
-※GPGを使用しない環境で下記を実行する場合は、mvnコマンドに ``-Dgpg.skip=true`` を付加して実行すること。
-
 ## nablarch-archetype-parent
 
 ```

--- a/nablarch-archetype-parent/pom.xml
+++ b/nablarch-archetype-parent/pom.xml
@@ -42,6 +42,7 @@
     <version.plugins.javadoc>3.4.1</version.plugins.javadoc>
     <version.plugins.resources>2.7</version.plugins.resources>
     <version.plugins.source>2.4</version.plugins.source>
+    <version.plugins.gpg>1.5</version.plugins.gpg>
     <version.plugins.jacoco>0.8.11</version.plugins.jacoco>
     <version.plugins.build-helper-maven>1.9.1</version.plugins.build-helper-maven>
     <version.plugins.jib>2.1.0</version.plugins.jib>
@@ -418,4 +419,64 @@
       </extension>
     </extensions>
   </build>
+
+  <profiles>
+    <profile>
+      <id>ossrh</id>
+      <distributionManagement>
+        <repository>
+          <id>nablarch.staging</id>
+          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+        </repository>
+        <snapshotRepository>
+          <id>nablarch.snapshot</id>
+          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+      </distributionManagement>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>${version.plugins.source}</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>${version.plugins.javadoc}</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>${version.plugins.gpg}</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
#179 のv5対応版です。

動作確認内容。

- [x] ossrh profileを追加してmvn installし、アーキタイプが作成できること
- [x] アーキタイプから作成したプロジェクトが動作すること
- [x] アーキタイプから作成したプロジェクトで、mvn help:all-profilesでossrh profileが出現すること