### PR TITLE
アーキタイプをMaven Centralにデプロイできるように修正

### DIFF
--- a/nablarch-archetype-build-parent/pom.xml
+++ b/nablarch-archetype-build-parent/pom.xml
@@ -17,6 +17,10 @@
   <version>6-NEXT-SNAPSHOT</version>
   <packaging>pom</packaging>
 
+  <name>nablarch-archetype-build-parent</name>
+  <description>Nablarch Framework.</description>
+  <url>https://github.com/nablarch</url>
+
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>

--- a/nablarch-archetype-parent/pom.xml
+++ b/nablarch-archetype-parent/pom.xml
@@ -20,6 +20,30 @@
   <description>Nablarch Framework.</description>
   <url>https://github.com/nablarch</url>
 
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <id>nablarch</id>
+      <name>Nablarch</name>
+      <email>nablarch@tis.co.jp</email>
+      <organization>Nablarch</organization>
+      <organizationUrl>https://github.com/nablarch</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:git://github.com/nablarch/nablarch/nablarch-single-module-archetype.git</connection>
+    <developerConnection>scm:git:ssh://github.com/nablarch/nablarch/nablarch-single-module-archetype.git</developerConnection>
+    <url>https://github.com/nablarch/nablarch-single-module-archetype/tree/master</url>
+    <tag>HEAD</tag>
+  </scm>
+
   <properties>
     <java.version>17</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>

--- a/nablarch-batch-dbless/pom.xml
+++ b/nablarch-batch-dbless/pom.xml
@@ -12,6 +12,19 @@
   <version>6-NEXT-SNAPSHOT</version>
   <packaging>jar</packaging>
 
+  <licenses>
+    <license/>
+  </licenses>
+  <developers>
+    <developer/>
+  </developers>
+  <scm>
+    <connection/>
+    <developerConnection/>
+    <tag/>
+    <url/>
+  </scm>
+
   <properties>
     <!-- ソース及びclassファイルが準拠するJavaのバージョン-->
     <java.version>17</java.version>

--- a/nablarch-batch-ee/pom.xml
+++ b/nablarch-batch-ee/pom.xml
@@ -12,6 +12,18 @@
   <artifactId>nablarch-batch-ee</artifactId>
   <version>6-NEXT-SNAPSHOT</version>
 
+  <licenses>
+    <license/>
+  </licenses>
+  <developers>
+    <developer/>
+  </developers>
+  <scm>
+    <connection/>
+    <developerConnection/>
+    <tag/>
+    <url/>
+  </scm>
 
   <!-- DB接続設定とビルド設定 -->
   <properties>

--- a/nablarch-batch/pom.xml
+++ b/nablarch-batch/pom.xml
@@ -12,6 +12,19 @@
   <version>6-NEXT-SNAPSHOT</version>
   <packaging>jar</packaging>
 
+  <licenses>
+    <license/>
+  </licenses>
+  <developers>
+    <developer/>
+  </developers>
+  <scm>
+    <connection/>
+    <developerConnection/>
+    <tag/>
+    <url/>
+  </scm>
+
   <properties>
     <!-- ソース及びclassファイルが準拠するJavaのバージョン-->
     <java.version>17</java.version>

--- a/nablarch-container-batch-dbless/pom.xml
+++ b/nablarch-container-batch-dbless/pom.xml
@@ -12,6 +12,19 @@
   <version>6-NEXT-SNAPSHOT</version>
   <packaging>jar</packaging>
 
+  <licenses>
+    <license/>
+  </licenses>
+  <developers>
+    <developer/>
+  </developers>
+  <scm>
+    <connection/>
+    <developerConnection/>
+    <tag/>
+    <url/>
+  </scm>
+
   <properties>
     <!-- ソース及びclassファイルが準拠するJavaのバージョン-->
     <java.version>17</java.version>

--- a/nablarch-container-batch/pom.xml
+++ b/nablarch-container-batch/pom.xml
@@ -12,6 +12,19 @@
   <version>6-NEXT-SNAPSHOT</version>
   <packaging>jar</packaging>
 
+  <licenses>
+    <license/>
+  </licenses>
+  <developers>
+    <developer/>
+  </developers>
+  <scm>
+    <connection/>
+    <developerConnection/>
+    <tag/>
+    <url/>
+  </scm>
+
   <properties>
     <!-- ソース及びclassファイルが準拠するJavaのバージョン-->
     <java.version>17</java.version>

--- a/nablarch-container-jaxrs/pom.xml
+++ b/nablarch-container-jaxrs/pom.xml
@@ -13,6 +13,19 @@
   <version>6-NEXT-SNAPSHOT</version>
   <packaging>war</packaging>
 
+  <licenses>
+    <license/>
+  </licenses>
+  <developers>
+    <developer/>
+  </developers>
+  <scm>
+    <connection/>
+    <developerConnection/>
+    <tag/>
+    <url/>
+  </scm>
+
   <properties>
     <!-- ソース及びclassファイルが準拠するJavaのバージョン-->
     <java.version>17</java.version>

--- a/nablarch-container-web/pom.xml
+++ b/nablarch-container-web/pom.xml
@@ -12,6 +12,19 @@
   <version>6-NEXT-SNAPSHOT</version>
   <packaging>war</packaging>
 
+  <licenses>
+    <license/>
+  </licenses>
+  <developers>
+    <developer/>
+  </developers>
+  <scm>
+    <connection/>
+    <developerConnection/>
+    <tag/>
+    <url/>
+  </scm>
+
   <properties>
     <!-- ソース及びclassファイルが準拠するJavaのバージョン-->
     <java.version>17</java.version>

--- a/nablarch-jaxrs/pom.xml
+++ b/nablarch-jaxrs/pom.xml
@@ -13,6 +13,19 @@
   <version>6-NEXT-SNAPSHOT</version>
   <packaging>war</packaging>
 
+  <licenses>
+    <license/>
+  </licenses>
+  <developers>
+    <developer/>
+  </developers>
+  <scm>
+    <connection/>
+    <developerConnection/>
+    <tag/>
+    <url/>
+  </scm>
+
   <properties>
     <!-- ソース及びclassファイルが準拠するJavaのバージョン-->
     <java.version>17</java.version>

--- a/nablarch-web/pom.xml
+++ b/nablarch-web/pom.xml
@@ -12,6 +12,19 @@
   <version>6-NEXT-SNAPSHOT</version>
   <packaging>war</packaging>
 
+  <licenses>
+    <license/>
+  </licenses>
+  <developers>
+    <developer/>
+  </developers>
+  <scm>
+    <connection/>
+    <developerConnection/>
+    <tag/>
+    <url/>
+  </scm>
+
   <properties>
     <!-- ソース及びclassファイルが準拠するJavaのバージョン-->
     <java.version>17</java.version>

--- a/pre-create-maven-archetype-batch-dbless.sh
+++ b/pre-create-maven-archetype-batch-dbless.sh
@@ -6,8 +6,8 @@ BUILD_PARENT_GROUP_ID=com.nablarch.archetype
 BUILD_PARENT_ARTIFACT_ID=nablarch-archetype-build-parent
 BUILD_PARENT_VERSION=$(grep -E '^  <version>(.+)</version>$' ${SCRIPT_DIR}/nablarch-archetype-build-parent/pom.xml | sed -r 's|^  <version>(.+)</version>$|\1|')
 
-# archetypeのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomをnablarch-archetype-build-parentとなるように書き換える。
-sed -iorig 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' ./nablarch-batch-dbless/target/generated-sources/archetype/pom.xml
+# archetypeのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomをnablarch-archetype-build-parentとなるように書き換え、developers、licenses、scmを消去する。
+sed -iorig -e 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' -r -e 's! *</?(developers?|licenses?|scm).*!!' ./nablarch-batch-dbless/target/generated-sources/archetype/pom.xml
 
 # .gitignoreを配置する
 cp ./gitignore/.gitignore ./nablarch-batch-dbless/target/generated-sources/archetype/src/main/resources/archetype-resources

--- a/pre-create-maven-archetype-batch-ee.sh
+++ b/pre-create-maven-archetype-batch-ee.sh
@@ -7,8 +7,8 @@ BUILD_PARENT_GROUP_ID=com.nablarch.archetype
 BUILD_PARENT_ARTIFACT_ID=nablarch-archetype-build-parent
 BUILD_PARENT_VERSION=$(grep -E '^  <version>(.+)</version>$' ${SCRIPT_DIR}/nablarch-archetype-build-parent/pom.xml | sed -r 's|^  <version>(.+)</version>$|\1|')
 
-# archetypeのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomをnablarch-archetype-build-parentとなるように書き換える。
-sed -iorig 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' ./nablarch-batch-ee/target/generated-sources/archetype/pom.xml
+# archetypeのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomをnablarch-archetype-build-parentとなるように書き換え、developers、licenses、scmを消去する。
+sed -iorig -e 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' -r -e 's! *</?(developers?|licenses?|scm).*!!' ./nablarch-batch-ee/target/generated-sources/archetype/pom.xml
 
 # .gitignoreを配置する
 cp ./gitignore/.gitignore ./nablarch-batch-ee/target/generated-sources/archetype/src/main/resources/archetype-resources

--- a/pre-create-maven-archetype-batch.sh
+++ b/pre-create-maven-archetype-batch.sh
@@ -6,8 +6,8 @@ BUILD_PARENT_GROUP_ID=com.nablarch.archetype
 BUILD_PARENT_ARTIFACT_ID=nablarch-archetype-build-parent
 BUILD_PARENT_VERSION=$(grep -E '^  <version>(.+)</version>$' ${SCRIPT_DIR}/nablarch-archetype-build-parent/pom.xml | sed -r 's|^  <version>(.+)</version>$|\1|')
 
-# archetypeのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomをnablarch-archetype-build-parentとなるように書き換える。
-sed -iorig 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' ./nablarch-batch/target/generated-sources/archetype/pom.xml
+# archetypeのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomをnablarch-archetype-build-parentとなるように書き換え、developers、licenses、scmを消去する。
+sed -iorig -e 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' -r -e 's! *</?(developers?|licenses?|scm).*!!' ./nablarch-batch/target/generated-sources/archetype/pom.xml
 
 # .gitignoreを配置する
 cp ./gitignore/.gitignore ./nablarch-batch/target/generated-sources/archetype/src/main/resources/archetype-resources

--- a/pre-create-maven-archetype-container-batch-dbless.sh
+++ b/pre-create-maven-archetype-container-batch-dbless.sh
@@ -6,8 +6,8 @@ BUILD_PARENT_GROUP_ID=com.nablarch.archetype
 BUILD_PARENT_ARTIFACT_ID=nablarch-archetype-build-parent
 BUILD_PARENT_VERSION=$(grep -E '^  <version>(.+)</version>$' ${SCRIPT_DIR}/nablarch-archetype-build-parent/pom.xml | sed -r 's|^  <version>(.+)</version>$|\1|')
 
-# archetypeのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomをnablarch-archetype-build-parentとなるように書き換える。
-sed -iorig 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' ./nablarch-container-batch-dbless/target/generated-sources/archetype/pom.xml
+# archetypeのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomをnablarch-archetype-build-parentとなるように書き換え、developers、licenses、scmを消去する。
+sed -iorig -e 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' -r -e 's! *</?(developers?|licenses?|scm).*!!' ./nablarch-container-batch-dbless/target/generated-sources/archetype/pom.xml
 
 # .gitignoreを配置する
 cp ./gitignore/.gitignore ./nablarch-container-batch-dbless/target/generated-sources/archetype/src/main/resources/archetype-resources

--- a/pre-create-maven-archetype-container-batch.sh
+++ b/pre-create-maven-archetype-container-batch.sh
@@ -6,8 +6,8 @@ BUILD_PARENT_GROUP_ID=com.nablarch.archetype
 BUILD_PARENT_ARTIFACT_ID=nablarch-archetype-build-parent
 BUILD_PARENT_VERSION=$(grep -E '^  <version>(.+)</version>$' ${SCRIPT_DIR}/nablarch-archetype-build-parent/pom.xml | sed -r 's|^  <version>(.+)</version>$|\1|')
 
-# archetypeのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomをnablarch-archetype-build-parentとなるように書き換える。
-sed -iorig 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' ./nablarch-container-batch/target/generated-sources/archetype/pom.xml
+# archetypeのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomをnablarch-archetype-build-parentとなるように書き換え、developers、licenses、scmを消去する。
+sed -iorig -e 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' -r -e 's! *</?(developers?|licenses?|scm).*!!' ./nablarch-container-batch/target/generated-sources/archetype/pom.xml
 
 # .gitignoreを配置する
 cp ./gitignore/.gitignore ./nablarch-container-batch/target/generated-sources/archetype/src/main/resources/archetype-resources

--- a/pre-create-maven-archetype-container-jaxrs.sh
+++ b/pre-create-maven-archetype-container-jaxrs.sh
@@ -6,8 +6,8 @@ BUILD_PARENT_GROUP_ID=com.nablarch.archetype
 BUILD_PARENT_ARTIFACT_ID=nablarch-archetype-build-parent
 BUILD_PARENT_VERSION=$(grep -E '^  <version>(.+)</version>$' ${SCRIPT_DIR}/nablarch-archetype-build-parent/pom.xml | sed -r 's|^  <version>(.+)</version>$|\1|')
 
-# archetypeのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomをnablarch-archetype-build-parentとなるように書き換える。
-sed -iorig 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' ./nablarch-container-jaxrs/target/generated-sources/archetype/pom.xml
+# archetypeのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomをnablarch-archetype-build-parentとなるように書き換え、developers、licenses、scmを消去する。
+sed -iorig -e 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' -r -e 's! *</?(developers?|licenses?|scm).*!!' ./nablarch-container-jaxrs/target/generated-sources/archetype/pom.xml
 
 # .gitignoreを配置する
 cp ./gitignore/.gitignore ./nablarch-container-jaxrs/target/generated-sources/archetype/src/main/resources/archetype-resources

--- a/pre-create-maven-archetype-container-web.sh
+++ b/pre-create-maven-archetype-container-web.sh
@@ -6,8 +6,8 @@ BUILD_PARENT_GROUP_ID=com.nablarch.archetype
 BUILD_PARENT_ARTIFACT_ID=nablarch-archetype-build-parent
 BUILD_PARENT_VERSION=$(grep -E '^  <version>(.+)</version>$' ${SCRIPT_DIR}/nablarch-archetype-build-parent/pom.xml | sed -r 's|^  <version>(.+)</version>$|\1|')
 
-# archetypeのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomをnablarch-archetype-build-parentとなるように書き換える。
-sed -iorig 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' ./nablarch-container-web/target/generated-sources/archetype/pom.xml
+# archetypeのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomをnablarch-archetype-build-parentとなるように書き換え、developers、licenses、scmを消去する。
+sed -iorig -e 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' -r -e 's! *</?(developers?|licenses?|scm).*!!' ./nablarch-container-web/target/generated-sources/archetype/pom.xml
 
 # .gitignoreを配置する
 cp ./gitignore/.gitignore ./nablarch-container-web/target/generated-sources/archetype/src/main/resources/archetype-resources

--- a/pre-create-maven-archetype-jaxrs.sh
+++ b/pre-create-maven-archetype-jaxrs.sh
@@ -6,8 +6,8 @@ BUILD_PARENT_GROUP_ID=com.nablarch.archetype
 BUILD_PARENT_ARTIFACT_ID=nablarch-archetype-build-parent
 BUILD_PARENT_VERSION=$(grep -E '^  <version>(.+)</version>$' ${SCRIPT_DIR}/nablarch-archetype-build-parent/pom.xml | sed -r 's|^  <version>(.+)</version>$|\1|')
  
-# archetypeのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomをnablarch-archetype-build-parentとなるように書き換える。
-sed -iorig 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' ./nablarch-jaxrs/target/generated-sources/archetype/pom.xml
+# archetypeのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomをnablarch-archetype-build-parentとなるように書き換え、developers、licenses、scmを消去する。
+sed -iorig -e 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' -r -e 's! *</?(developers?|licenses?|scm).*!!' ./nablarch-jaxrs/target/generated-sources/archetype/pom.xml
 
 # .gitignoreを配置する
 cp ./gitignore/.gitignore ./nablarch-jaxrs/target/generated-sources/archetype/src/main/resources/archetype-resources

--- a/pre-create-maven-archetype-web.sh
+++ b/pre-create-maven-archetype-web.sh
@@ -6,8 +6,8 @@ BUILD_PARENT_GROUP_ID=com.nablarch.archetype
 BUILD_PARENT_ARTIFACT_ID=nablarch-archetype-build-parent
 BUILD_PARENT_VERSION=$(grep -E '^  <version>(.+)</version>$' ${SCRIPT_DIR}/nablarch-archetype-build-parent/pom.xml | sed -r 's|^  <version>(.+)</version>$|\1|')
 
-# archetypeのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomをnablarch-archetype-build-parentとなるように書き換える。
-sed -iorig 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' ./nablarch-web/target/generated-sources/archetype/pom.xml
+# archetypeのデプロイで利用されるpom.xml(archetype:create-from-projectで生成される)の親pomをnablarch-archetype-build-parentとなるように書き換え、developers、licenses、scmを消去する。
+sed -iorig -e 's|/modelVersion>|/modelVersion>\n\n  <parent>\n    <groupId>'${BUILD_PARENT_GROUP_ID}'</groupId>\n    <artifactId>'${BUILD_PARENT_ARTIFACT_ID}'</artifactId>\n    <version>'${BUILD_PARENT_VERSION}'</version>\n  </parent>|' -r -e 's! *</?(developers?|licenses?|scm).*!!' ./nablarch-web/target/generated-sources/archetype/pom.xml
 
 # .gitignoreを配置する
 cp ./gitignore/.gitignore ./nablarch-web/target/generated-sources/archetype/src/main/resources/archetype-resources


### PR DESCRIPTION
# 概要

OSSRH（Maven Central）へのデプロイ時に、以下のエラーが発生。

```
failureMessage	Invalid POM: /com/nablarch/archetype/nablarch-archetype-parent/6u2/nablarch-archetype-parent-6u2.pom: License information missing, SCM URL missing, Developer information missing
failureMessage	Invalid POM: /com/nablarch/archetype/nablarch-archetype-build-parent/6u2/nablarch-archetype-build-parent-6u2.pom: Project name missing, Project description missing, Project URL missing
```

どちらもMaven Centralへのデプロイが必要であるが、nablarch-archetype-parent、nablarch-archetype-build-parentそれぞれで情報が不足しており、特にnablarch-archetype-parentは1度削除した情報が必要なことが発覚。

このため、nablarch-archetype-parentには削除したdevelopers、licenses、scmの情報を戻すとともに、アーキタイプから生成されるプロジェクトにはこれらの情報を空で上書きし、parentの情報をそのまま使わないように変更。

# 確認

以下の内容を確認しています。

- 修正したスクリプトを使い、アーキタイプ自身からはdevelopers、licenses、scmが削除されていること
- アーキタイプから生成されるプロジェクトには、developers、licenses、scmが空で設定されていること