### PR TITLE
licenses等に補足コメントを追加、親のAL v2表記を見直し

### DIFF
--- a/nablarch-archetype-build-parent/pom.xml
+++ b/nablarch-archetype-build-parent/pom.xml
@@ -23,7 +23,7 @@
 
   <licenses>
     <license>
-      <name>The Apache Software License, Version 2.0</name>
+      <name>The Apache License, Version 2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/nablarch-archetype-parent/pom.xml
+++ b/nablarch-archetype-parent/pom.xml
@@ -22,7 +22,7 @@
 
   <licenses>
     <license>
-      <name>The Apache Software License, Version 2.0</name>
+      <name>The Apache License, Version 2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>

--- a/nablarch-batch-dbless/pom.xml
+++ b/nablarch-batch-dbless/pom.xml
@@ -12,13 +12,24 @@
   <version>6-NEXT-SNAPSHOT</version>
   <packaging>jar</packaging>
 
+  <!--
+   licenses、developers、scmはブランクプロジェクトの親であるnablarch-archetype-parentの
+   Maven Centralへのデプロイに必須の要件であり、ブランクプロジェクトでは親からこれらの情報を
+   継承しないよう明示的に空の値を設定して上書きしている。
+   値は必要に応じて、プロジェクトで変更すること。
+   また、これらの要素を削除した場合は親であるnablarch-archetype-parentの定義を継承することに
+   なるため注意すること。たとえば、ライセンスはApache License, Version 2.0を設定していることになる。
+  -->
   <licenses>
+    <!-- プロジェクトのライセンスを設定する -->
     <license/>
   </licenses>
   <developers>
+    <!-- プロジェクトの開発者情報を設定する -->
     <developer/>
   </developers>
   <scm>
+    <!-- プロジェクトのバージョン管理システムの情報を設定する -->
     <connection/>
     <developerConnection/>
     <tag/>

--- a/nablarch-batch-dbless/pom.xml
+++ b/nablarch-batch-dbless/pom.xml
@@ -13,23 +13,17 @@
   <packaging>jar</packaging>
 
   <!--
-   licenses、developers、scmはブランクプロジェクトの親であるnablarch-archetype-parentの
-   Maven Centralへのデプロイに必須の要件であり、ブランクプロジェクトでは親からこれらの情報を
-   継承しないよう明示的に空の値を設定して上書きしている。
-   値は必要に応じて、プロジェクトで変更すること。
-   また、これらの要素を削除した場合は親であるnablarch-archetype-parentの定義を継承することに
-   なるため注意すること。たとえば、ライセンスはApache License, Version 2.0を設定していることになる。
+   ライセンス、開発者やSCMといったプロジェクト自身に関する情報は、親pomの情報を
+   引き継がないように空の値で上書きしている。
+   これらの値は、必要に応じてプロジェクトで変更すること。
   -->
   <licenses>
-    <!-- プロジェクトのライセンスを設定する -->
     <license/>
   </licenses>
   <developers>
-    <!-- プロジェクトの開発者情報を設定する -->
     <developer/>
   </developers>
   <scm>
-    <!-- プロジェクトのバージョン管理システムの情報を設定する -->
     <connection/>
     <developerConnection/>
     <tag/>

--- a/nablarch-batch-ee/pom.xml
+++ b/nablarch-batch-ee/pom.xml
@@ -12,13 +12,24 @@
   <artifactId>nablarch-batch-ee</artifactId>
   <version>6-NEXT-SNAPSHOT</version>
 
+  <!--
+   licenses、developers、scmはブランクプロジェクトの親であるnablarch-archetype-parentの
+   Maven Centralへのデプロイに必須の要件であり、ブランクプロジェクトでは親からこれらの情報を
+   継承しないよう明示的に空の値を設定して上書きしている。
+   値は必要に応じて、プロジェクトで変更すること。
+   また、これらの要素を削除した場合は親であるnablarch-archetype-parentの定義を継承することに
+   なるため注意すること。たとえば、ライセンスはApache License, Version 2.0を設定していることになる。
+  -->
   <licenses>
+    <!-- プロジェクトのライセンスを設定する -->
     <license/>
   </licenses>
   <developers>
+    <!-- プロジェクトの開発者情報を設定する -->
     <developer/>
   </developers>
   <scm>
+    <!-- プロジェクトのバージョン管理システムの情報を設定する -->
     <connection/>
     <developerConnection/>
     <tag/>

--- a/nablarch-batch-ee/pom.xml
+++ b/nablarch-batch-ee/pom.xml
@@ -13,23 +13,17 @@
   <version>6-NEXT-SNAPSHOT</version>
 
   <!--
-   licenses、developers、scmはブランクプロジェクトの親であるnablarch-archetype-parentの
-   Maven Centralへのデプロイに必須の要件であり、ブランクプロジェクトでは親からこれらの情報を
-   継承しないよう明示的に空の値を設定して上書きしている。
-   値は必要に応じて、プロジェクトで変更すること。
-   また、これらの要素を削除した場合は親であるnablarch-archetype-parentの定義を継承することに
-   なるため注意すること。たとえば、ライセンスはApache License, Version 2.0を設定していることになる。
+   ライセンス、開発者やSCMといったプロジェクト自身に関する情報は、親pomの情報を
+   引き継がないように空の値で上書きしている。
+   これらの値は、必要に応じてプロジェクトで変更すること。
   -->
   <licenses>
-    <!-- プロジェクトのライセンスを設定する -->
     <license/>
   </licenses>
   <developers>
-    <!-- プロジェクトの開発者情報を設定する -->
     <developer/>
   </developers>
   <scm>
-    <!-- プロジェクトのバージョン管理システムの情報を設定する -->
     <connection/>
     <developerConnection/>
     <tag/>

--- a/nablarch-batch/pom.xml
+++ b/nablarch-batch/pom.xml
@@ -12,13 +12,24 @@
   <version>6-NEXT-SNAPSHOT</version>
   <packaging>jar</packaging>
 
+  <!--
+   licenses、developers、scmはブランクプロジェクトの親であるnablarch-archetype-parentの
+   Maven Centralへのデプロイに必須の要件であり、ブランクプロジェクトでは親からこれらの情報を
+   継承しないよう明示的に空の値を設定して上書きしている。
+   値は必要に応じて、プロジェクトで変更すること。
+   また、これらの要素を削除した場合は親であるnablarch-archetype-parentの定義を継承することに
+   なるため注意すること。たとえば、ライセンスはApache License, Version 2.0を設定していることになる。
+  -->
   <licenses>
+    <!-- プロジェクトのライセンスを設定する -->
     <license/>
   </licenses>
   <developers>
+    <!-- プロジェクトの開発者情報を設定する -->
     <developer/>
   </developers>
   <scm>
+    <!-- プロジェクトのバージョン管理システムの情報を設定する -->
     <connection/>
     <developerConnection/>
     <tag/>

--- a/nablarch-batch/pom.xml
+++ b/nablarch-batch/pom.xml
@@ -13,23 +13,17 @@
   <packaging>jar</packaging>
 
   <!--
-   licenses、developers、scmはブランクプロジェクトの親であるnablarch-archetype-parentの
-   Maven Centralへのデプロイに必須の要件であり、ブランクプロジェクトでは親からこれらの情報を
-   継承しないよう明示的に空の値を設定して上書きしている。
-   値は必要に応じて、プロジェクトで変更すること。
-   また、これらの要素を削除した場合は親であるnablarch-archetype-parentの定義を継承することに
-   なるため注意すること。たとえば、ライセンスはApache License, Version 2.0を設定していることになる。
+   ライセンス、開発者やSCMといったプロジェクト自身に関する情報は、親pomの情報を
+   引き継がないように空の値で上書きしている。
+   これらの値は、必要に応じてプロジェクトで変更すること。
   -->
   <licenses>
-    <!-- プロジェクトのライセンスを設定する -->
     <license/>
   </licenses>
   <developers>
-    <!-- プロジェクトの開発者情報を設定する -->
     <developer/>
   </developers>
   <scm>
-    <!-- プロジェクトのバージョン管理システムの情報を設定する -->
     <connection/>
     <developerConnection/>
     <tag/>

--- a/nablarch-container-batch-dbless/pom.xml
+++ b/nablarch-container-batch-dbless/pom.xml
@@ -12,13 +12,24 @@
   <version>6-NEXT-SNAPSHOT</version>
   <packaging>jar</packaging>
 
+  <!--
+   licenses、developers、scmはブランクプロジェクトの親であるnablarch-archetype-parentの
+   Maven Centralへのデプロイに必須の要件であり、ブランクプロジェクトでは親からこれらの情報を
+   継承しないよう明示的に空の値を設定して上書きしている。
+   値は必要に応じて、プロジェクトで変更すること。
+   また、これらの要素を削除した場合は親であるnablarch-archetype-parentの定義を継承することに
+   なるため注意すること。たとえば、ライセンスはApache License, Version 2.0を設定していることになる。
+  -->
   <licenses>
+    <!-- プロジェクトのライセンスを設定する -->
     <license/>
   </licenses>
   <developers>
+    <!-- プロジェクトの開発者情報を設定する -->
     <developer/>
   </developers>
   <scm>
+    <!-- プロジェクトのバージョン管理システムの情報を設定する -->
     <connection/>
     <developerConnection/>
     <tag/>

--- a/nablarch-container-batch-dbless/pom.xml
+++ b/nablarch-container-batch-dbless/pom.xml
@@ -13,23 +13,17 @@
   <packaging>jar</packaging>
 
   <!--
-   licenses、developers、scmはブランクプロジェクトの親であるnablarch-archetype-parentの
-   Maven Centralへのデプロイに必須の要件であり、ブランクプロジェクトでは親からこれらの情報を
-   継承しないよう明示的に空の値を設定して上書きしている。
-   値は必要に応じて、プロジェクトで変更すること。
-   また、これらの要素を削除した場合は親であるnablarch-archetype-parentの定義を継承することに
-   なるため注意すること。たとえば、ライセンスはApache License, Version 2.0を設定していることになる。
+   ライセンス、開発者やSCMといったプロジェクト自身に関する情報は、親pomの情報を
+   引き継がないように空の値で上書きしている。
+   これらの値は、必要に応じてプロジェクトで変更すること。
   -->
   <licenses>
-    <!-- プロジェクトのライセンスを設定する -->
     <license/>
   </licenses>
   <developers>
-    <!-- プロジェクトの開発者情報を設定する -->
     <developer/>
   </developers>
   <scm>
-    <!-- プロジェクトのバージョン管理システムの情報を設定する -->
     <connection/>
     <developerConnection/>
     <tag/>

--- a/nablarch-container-batch/pom.xml
+++ b/nablarch-container-batch/pom.xml
@@ -12,13 +12,24 @@
   <version>6-NEXT-SNAPSHOT</version>
   <packaging>jar</packaging>
 
+  <!--
+   licenses、developers、scmはブランクプロジェクトの親であるnablarch-archetype-parentの
+   Maven Centralへのデプロイに必須の要件であり、ブランクプロジェクトでは親からこれらの情報を
+   継承しないよう明示的に空の値を設定して上書きしている。
+   値は必要に応じて、プロジェクトで変更すること。
+   また、これらの要素を削除した場合は親であるnablarch-archetype-parentの定義を継承することに
+   なるため注意すること。たとえば、ライセンスはApache License, Version 2.0を設定していることになる。
+  -->
   <licenses>
+    <!-- プロジェクトのライセンスを設定する -->
     <license/>
   </licenses>
   <developers>
+    <!-- プロジェクトの開発者情報を設定する -->
     <developer/>
   </developers>
   <scm>
+    <!-- プロジェクトのバージョン管理システムの情報を設定する -->
     <connection/>
     <developerConnection/>
     <tag/>

--- a/nablarch-container-batch/pom.xml
+++ b/nablarch-container-batch/pom.xml
@@ -13,23 +13,17 @@
   <packaging>jar</packaging>
 
   <!--
-   licenses、developers、scmはブランクプロジェクトの親であるnablarch-archetype-parentの
-   Maven Centralへのデプロイに必須の要件であり、ブランクプロジェクトでは親からこれらの情報を
-   継承しないよう明示的に空の値を設定して上書きしている。
-   値は必要に応じて、プロジェクトで変更すること。
-   また、これらの要素を削除した場合は親であるnablarch-archetype-parentの定義を継承することに
-   なるため注意すること。たとえば、ライセンスはApache License, Version 2.0を設定していることになる。
+   ライセンス、開発者やSCMといったプロジェクト自身に関する情報は、親pomの情報を
+   引き継がないように空の値で上書きしている。
+   これらの値は、必要に応じてプロジェクトで変更すること。
   -->
   <licenses>
-    <!-- プロジェクトのライセンスを設定する -->
     <license/>
   </licenses>
   <developers>
-    <!-- プロジェクトの開発者情報を設定する -->
     <developer/>
   </developers>
   <scm>
-    <!-- プロジェクトのバージョン管理システムの情報を設定する -->
     <connection/>
     <developerConnection/>
     <tag/>

--- a/nablarch-container-jaxrs/pom.xml
+++ b/nablarch-container-jaxrs/pom.xml
@@ -13,13 +13,24 @@
   <version>6-NEXT-SNAPSHOT</version>
   <packaging>war</packaging>
 
+  <!--
+   licenses、developers、scmはブランクプロジェクトの親であるnablarch-archetype-parentの
+   Maven Centralへのデプロイに必須の要件であり、ブランクプロジェクトでは親からこれらの情報を
+   継承しないよう明示的に空の値を設定して上書きしている。
+   値は必要に応じて、プロジェクトで変更すること。
+   また、これらの要素を削除した場合は親であるnablarch-archetype-parentの定義を継承することに
+   なるため注意すること。たとえば、ライセンスはApache License, Version 2.0を設定していることになる。
+  -->
   <licenses>
+    <!-- プロジェクトのライセンスを設定する -->
     <license/>
   </licenses>
   <developers>
+    <!-- プロジェクトの開発者情報を設定する -->
     <developer/>
   </developers>
   <scm>
+    <!-- プロジェクトのバージョン管理システムの情報を設定する -->
     <connection/>
     <developerConnection/>
     <tag/>

--- a/nablarch-container-jaxrs/pom.xml
+++ b/nablarch-container-jaxrs/pom.xml
@@ -14,26 +14,22 @@
   <packaging>war</packaging>
 
   <!--
-   licenses、developers、scmはブランクプロジェクトの親であるnablarch-archetype-parentの
-   Maven Centralへのデプロイに必須の要件であり、ブランクプロジェクトでは親からこれらの情報を
-   継承しないよう明示的に空の値を設定して上書きしている。
-   値は必要に応じて、プロジェクトで変更すること。
-   また、これらの要素を削除した場合は親であるnablarch-archetype-parentの定義を継承することに
-   なるため注意すること。たとえば、ライセンスはApache License, Version 2.0を設定していることになる。
+   ライセンス、開発者やSCMといったプロジェクト自身に関する情報は、親pomの情報を
+   引き継がないように空の値で上書きしている。
+   これらの値は、必要に応じてプロジェクトで変更すること。
   -->
   <licenses>
-    <!-- プロジェクトのライセンスを設定する -->
     <license/>
   </licenses>
   <developers>
-    <!-- プロジェクトの開発者情報を設定する -->
     <developer/>
   </developers>
   <scm>
-    <!-- プロジェクトのバージョン管理システムの情報を設定する -->
     <connection/>
     <developerConnection/>
     <tag/>
+    <url/>
+  </scm>
     <url/>
   </scm>
 

--- a/nablarch-container-web/pom.xml
+++ b/nablarch-container-web/pom.xml
@@ -12,13 +12,24 @@
   <version>6-NEXT-SNAPSHOT</version>
   <packaging>war</packaging>
 
+  <!--
+   licenses、developers、scmはブランクプロジェクトの親であるnablarch-archetype-parentの
+   Maven Centralへのデプロイに必須の要件であり、ブランクプロジェクトでは親からこれらの情報を
+   継承しないよう明示的に空の値を設定して上書きしている。
+   値は必要に応じて、プロジェクトで変更すること。
+   また、これらの要素を削除した場合は親であるnablarch-archetype-parentの定義を継承することに
+   なるため注意すること。たとえば、ライセンスはApache License, Version 2.0を設定していることになる。
+  -->
   <licenses>
+    <!-- プロジェクトのライセンスを設定する -->
     <license/>
   </licenses>
   <developers>
+    <!-- プロジェクトの開発者情報を設定する -->
     <developer/>
   </developers>
   <scm>
+    <!-- プロジェクトのバージョン管理システムの情報を設定する -->
     <connection/>
     <developerConnection/>
     <tag/>

--- a/nablarch-container-web/pom.xml
+++ b/nablarch-container-web/pom.xml
@@ -13,23 +13,17 @@
   <packaging>war</packaging>
 
   <!--
-   licenses、developers、scmはブランクプロジェクトの親であるnablarch-archetype-parentの
-   Maven Centralへのデプロイに必須の要件であり、ブランクプロジェクトでは親からこれらの情報を
-   継承しないよう明示的に空の値を設定して上書きしている。
-   値は必要に応じて、プロジェクトで変更すること。
-   また、これらの要素を削除した場合は親であるnablarch-archetype-parentの定義を継承することに
-   なるため注意すること。たとえば、ライセンスはApache License, Version 2.0を設定していることになる。
+   ライセンス、開発者やSCMといったプロジェクト自身に関する情報は、親pomの情報を
+   引き継がないように空の値で上書きしている。
+   これらの値は、必要に応じてプロジェクトで変更すること。
   -->
   <licenses>
-    <!-- プロジェクトのライセンスを設定する -->
     <license/>
   </licenses>
   <developers>
-    <!-- プロジェクトの開発者情報を設定する -->
     <developer/>
   </developers>
   <scm>
-    <!-- プロジェクトのバージョン管理システムの情報を設定する -->
     <connection/>
     <developerConnection/>
     <tag/>

--- a/nablarch-jaxrs/pom.xml
+++ b/nablarch-jaxrs/pom.xml
@@ -14,23 +14,17 @@
   <packaging>war</packaging>
 
   <!--
-   licenses、developers、scmはブランクプロジェクトの親であるnablarch-archetype-parentの
-   Maven Centralへのデプロイに必須の要件であり、ブランクプロジェクトでは親からこれらの情報を
-   継承しないよう明示的に空の値を設定して上書きしている。
-   値は必要に応じて、プロジェクトで変更すること。
-   また、これらの要素を削除した場合は親であるnablarch-archetype-parentの定義を継承することに
-   なるため注意すること。たとえば、ライセンスはApache License, Version 2.0を設定していることになる。
+   ライセンス、開発者やSCMといったプロジェクト自身に関する情報は、親pomの情報を
+   引き継がないように空の値で上書きしている。
+   これらの値は、必要に応じてプロジェクトで変更すること。
   -->
   <licenses>
-    <!-- プロジェクトのライセンスを設定する -->
     <license/>
   </licenses>
   <developers>
-    <!-- プロジェクトの開発者情報を設定する -->
     <developer/>
   </developers>
   <scm>
-    <!-- プロジェクトのバージョン管理システムの情報を設定する -->
     <connection/>
     <developerConnection/>
     <tag/>

--- a/nablarch-jaxrs/pom.xml
+++ b/nablarch-jaxrs/pom.xml
@@ -13,13 +13,24 @@
   <version>6-NEXT-SNAPSHOT</version>
   <packaging>war</packaging>
 
+  <!--
+   licenses、developers、scmはブランクプロジェクトの親であるnablarch-archetype-parentの
+   Maven Centralへのデプロイに必須の要件であり、ブランクプロジェクトでは親からこれらの情報を
+   継承しないよう明示的に空の値を設定して上書きしている。
+   値は必要に応じて、プロジェクトで変更すること。
+   また、これらの要素を削除した場合は親であるnablarch-archetype-parentの定義を継承することに
+   なるため注意すること。たとえば、ライセンスはApache License, Version 2.0を設定していることになる。
+  -->
   <licenses>
+    <!-- プロジェクトのライセンスを設定する -->
     <license/>
   </licenses>
   <developers>
+    <!-- プロジェクトの開発者情報を設定する -->
     <developer/>
   </developers>
   <scm>
+    <!-- プロジェクトのバージョン管理システムの情報を設定する -->
     <connection/>
     <developerConnection/>
     <tag/>

--- a/nablarch-web/pom.xml
+++ b/nablarch-web/pom.xml
@@ -12,13 +12,24 @@
   <version>6-NEXT-SNAPSHOT</version>
   <packaging>war</packaging>
 
+  <!--
+   licenses、developers、scmはブランクプロジェクトの親であるnablarch-archetype-parentの
+   Maven Centralへのデプロイに必須の要件であり、ブランクプロジェクトでは親からこれらの情報を
+   継承しないよう明示的に空の値を設定して上書きしている。
+   値は必要に応じて、プロジェクトで変更すること。
+   また、これらの要素を削除した場合は親であるnablarch-archetype-parentの定義を継承することに
+   なるため注意すること。たとえば、ライセンスはApache License, Version 2.0を設定していることになる。
+  -->
   <licenses>
+    <!-- プロジェクトのライセンスを設定する -->
     <license/>
   </licenses>
   <developers>
+    <!-- プロジェクトの開発者情報を設定する -->
     <developer/>
   </developers>
   <scm>
+    <!-- プロジェクトのバージョン管理システムの情報を設定する -->
     <connection/>
     <developerConnection/>
     <tag/>

--- a/nablarch-web/pom.xml
+++ b/nablarch-web/pom.xml
@@ -13,23 +13,17 @@
   <packaging>war</packaging>
 
   <!--
-   licenses、developers、scmはブランクプロジェクトの親であるnablarch-archetype-parentの
-   Maven Centralへのデプロイに必須の要件であり、ブランクプロジェクトでは親からこれらの情報を
-   継承しないよう明示的に空の値を設定して上書きしている。
-   値は必要に応じて、プロジェクトで変更すること。
-   また、これらの要素を削除した場合は親であるnablarch-archetype-parentの定義を継承することに
-   なるため注意すること。たとえば、ライセンスはApache License, Version 2.0を設定していることになる。
+   ライセンス、開発者やSCMといったプロジェクト自身に関する情報は、親pomの情報を
+   引き継がないように空の値で上書きしている。
+   これらの値は、必要に応じてプロジェクトで変更すること。
   -->
   <licenses>
-    <!-- プロジェクトのライセンスを設定する -->
     <license/>
   </licenses>
   <developers>
-    <!-- プロジェクトの開発者情報を設定する -->
     <developer/>
   </developers>
   <scm>
-    <!-- プロジェクトのバージョン管理システムの情報を設定する -->
     <connection/>
     <developerConnection/>
     <tag/>


### PR DESCRIPTION
# 概要

#181 の追加。ライセンス等に設定の意図が伝わるようにコメントを追加。

またアーキタイプの親のApache License, Version 2の表記がnablarch-parentと異なるものになっていたので修正。

https://github.com/nablarch/nablarch-parent/blob/master/pom.xml#L16-L21

少なくとも「Software」は不要。

https://www.apache.org/licenses/LICENSE-2.0