### PR TITLE
Jibを3.4.2にダウングレード

### DIFF
--- a/nablarch-archetype-parent/pom.xml
+++ b/nablarch-archetype-parent/pom.xml
@@ -68,7 +68,7 @@
     <version.plugins.gpg>3.2.5</version.plugins.gpg>
     <version.plugins.jacoco>0.8.12</version.plugins.jacoco>
     <version.plugins.build-helper-maven>3.6.0</version.plugins.build-helper-maven>
-    <version.plugins.jib>3.4.3</version.plugins.jib>
+    <version.plugins.jib>3.4.2</version.plugins.jib>
     <version.plugins.spotbugs>4.8.6.2</version.plugins.spotbugs>
     <spotbugs.version>4.8.6</spotbugs.version>
     <version.plugins.release>3.1.1</version.plugins.release>


### PR DESCRIPTION
Jib 3.4.3ではコンテナイメージビルド時にWindowsでハングアップするため、3.4.2にダウングレードする。

参考） `https://github.com/GoogleContainerTools/jib/issues/4267`

Linux環境でも3.4.2で各アーキタイプでコンテナイメージがビルドできることを確認。
