### PR TITLE
共通の設定ファイルと環境別設定ファイルのコピー順を固定するように修正（6u2）

### DIFF
--- a/nablarch-batch-dbless/pom.xml
+++ b/nablarch-batch-dbless/pom.xml
@@ -164,13 +164,21 @@
   <build>
     <resources>
       <resource>
-        <directory>${env.resources}</directory>
+        <directory>src/main/resources</directory>
       </resource>
       <resource>
-        <directory>src/main/resources</directory>
+        <directory>${env.resources}</directory>
       </resource>
     </resources>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <configuration>
+          <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+          <overwrite>true</overwrite>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>

--- a/nablarch-batch-ee/pom.xml
+++ b/nablarch-batch-ee/pom.xml
@@ -399,10 +399,10 @@
   <build>
     <resources>
       <resource>
-        <directory>${env.resources}</directory>
+        <directory>src/main/resources</directory>
       </resource>
       <resource>
-        <directory>src/main/resources</directory>
+        <directory>${env.resources}</directory>
       </resource>
       <resource>
         <directory>src/main/java</directory>
@@ -412,6 +412,14 @@
       </resource>
     </resources>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <configuration>
+          <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+          <overwrite>true</overwrite>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>

--- a/nablarch-batch/pom.xml
+++ b/nablarch-batch/pom.xml
@@ -350,10 +350,10 @@
   <build>
     <resources>
       <resource>
-        <directory>${env.resources}</directory>
+        <directory>src/main/resources</directory>
       </resource>
       <resource>
-        <directory>src/main/resources</directory>
+        <directory>${env.resources}</directory>
       </resource>
       <resource>
         <directory>src/main/java</directory>
@@ -363,6 +363,14 @@
       </resource>
     </resources>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <configuration>
+          <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+          <overwrite>true</overwrite>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>

--- a/nablarch-jaxrs/pom.xml
+++ b/nablarch-jaxrs/pom.xml
@@ -425,10 +425,10 @@
   <build>
     <resources>
       <resource>
-        <directory>${env.resources}</directory>
+        <directory>src/main/resources</directory>
       </resource>
       <resource>
-        <directory>src/main/resources</directory>
+        <directory>${env.resources}</directory>
       </resource>
       <resource>
         <directory>src/main/java</directory>
@@ -438,6 +438,14 @@
       </resource>
     </resources>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <configuration>
+          <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+          <overwrite>true</overwrite>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/nablarch-web/pom.xml
+++ b/nablarch-web/pom.xml
@@ -372,10 +372,10 @@
   <build>
     <resources>
       <resource>
-        <directory>${env.resources}</directory>
+        <directory>src/main/resources</directory>
       </resource>
       <resource>
-        <directory>src/main/resources</directory>
+        <directory>${env.resources}</directory>
       </resource>
       <resource>
         <directory>src/main/java</directory>
@@ -385,6 +385,14 @@
       </resource>
     </resources>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <configuration>
+          <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+          <overwrite>true</overwrite>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
# 概要

システム開発ガイドでの動作確認時に、共通の設定ファイルと環境別の設定ファイルのコピー順が不安定になることがあったため、順番を固定するように修正。  
対象はコンテナプロジェクト**以外**。

- リソースのコピー順を`src/main/resources`、`src/env/[環境名]/resources`に変更
- Maven Resource Pluginの`overwrite`プロパティを`true`にし、タイムスタンプに関わらず確実に上書きされるよう修正
  - `outputDirectory`はデフォルト値を指定しているが、IntelliJ上で警告されるため追加

# 動作確認

web、jaxrs、batch、batch-ee、batch-dblessでブランクプロジェクトを作成し、`mvn compile`を実行。  
この時に重複しているファイル（`log.properties`）を`src/main/resources`側を修正しても、`src/env/dev/resources`側のファイルが`target/classes`に配置されていることを確認。