### PR TITLE
Maven Resource PluginのoutputDirectory指定は全体で共通にすべきではないため削除（6u2）

### DIFF
--- a/nablarch-batch-dbless/pom.xml
+++ b/nablarch-batch-dbless/pom.xml
@@ -175,7 +175,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <configuration>
-          <outputDirectory>${project.build.outputDirectory}</outputDirectory>
           <overwrite>true</overwrite>
         </configuration>
       </plugin>

--- a/nablarch-batch-ee/pom.xml
+++ b/nablarch-batch-ee/pom.xml
@@ -416,7 +416,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <configuration>
-          <outputDirectory>${project.build.outputDirectory}</outputDirectory>
           <overwrite>true</overwrite>
         </configuration>
       </plugin>

--- a/nablarch-batch/pom.xml
+++ b/nablarch-batch/pom.xml
@@ -367,7 +367,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <configuration>
-          <outputDirectory>${project.build.outputDirectory}</outputDirectory>
           <overwrite>true</overwrite>
         </configuration>
       </plugin>

--- a/nablarch-jaxrs/pom.xml
+++ b/nablarch-jaxrs/pom.xml
@@ -442,7 +442,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <configuration>
-          <outputDirectory>${project.build.outputDirectory}</outputDirectory>
           <overwrite>true</overwrite>
         </configuration>
       </plugin>

--- a/nablarch-web/pom.xml
+++ b/nablarch-web/pom.xml
@@ -389,7 +389,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <configuration>
-          <outputDirectory>${project.build.outputDirectory}</outputDirectory>
           <overwrite>true</overwrite>
         </configuration>
       </plugin>


### PR DESCRIPTION
#190 でMaven Resource Pluginの設定を修正したが、ここで追加した`outputDirectory`を全体のゴールで共通で設定してしまうと通常のリソースとテスト用のリソースが混ざってしまうため誤り。  
よって削除する。

動作確認としては、nablarch-web用のアーキタイプで`mvn jetty:run`ができることを確認（`outputDirectory`を設定しているとこれができなかった）。