### PR TITLE
RESTful ウェブサービスのアーキタイプにマルチパートのサポートを追加

### DIFF
--- a/nablarch-container-jaxrs/src/main/resources/common.properties
+++ b/nablarch-container-jaxrs/src/main/resources/common.properties
@@ -26,6 +26,9 @@ nablarch.statementFactory.queryTimeout=600
 # トランザクション分離レベル
 nablarch.transactionFactory.isolationLevel=READ_COMMITTED
 
+# アップロード時に許容するContent-Lengthの最大値（バイト数）
+nablarch.uploadSettings.contentLengthLimit=1000000
+
 # SQLファイルのエンコーディング
 nablarch.sqlLoader.fileEncoding=utf-8
 

--- a/nablarch-container-jaxrs/src/main/resources/env.properties
+++ b/nablarch-container-jaxrs/src/main/resources/env.properties
@@ -43,3 +43,19 @@ nablarch.codeCache.loadOnStartUp=false
 # メッセージの初期ロード設定
 # (本番ではレスポンスを重視し初期ロードを実施する。開発環境では起動速度を重視し初期ロードはしない。)
 nablarch.stringResourceCache.loadOnStartup=false
+
+# フォーマット定義ファイルの格納ディレクトリ
+# (TODO: PJのファイルパスに変更する)
+nablarch.filePathSetting.basePathSettings.format=file:./src/main/format
+
+# 出力ファイルの出力先ディレクトリ
+# (TODO: PJのファイルパスに変更する)
+nablarch.filePathSetting.basePathSettings.output=file:./work/output
+
+# アップロードファイルの自動クリーニングを行うかどうか
+# (ディスクを逼迫するので本番環境ではtrue、開発環境などファイルを確認したい時はfalse)
+nablarch.uploadSettings.autoCleaning=true
+
+# アップロードファイル一時ディレクトリ
+# (TODO: PJのファイルパスに変更する)
+nablarch.filePathSetting.basePathSettings.uploadFileTmpDir=file:./work/tmp

--- a/nablarch-container-jaxrs/src/main/resources/rest-component-configuration.xml
+++ b/nablarch-container-jaxrs/src/main/resources/rest-component-configuration.xml
@@ -30,6 +30,12 @@
   <import file="nablarch/core/db-base.xml" />
   <import file="data-source.xml" />
 
+  <!-- ファイルパス設置 -->
+  <import file="nablarch/webui/filepath-for-webui.xml" />
+
+  <!-- ファイルアップロード機能設定 -->
+  <import file="nablarch/webui/multipart.xml" />
+
   <!-- スレッドコンテキストハンドラ -->
   <import file="nablarch/webui/threadcontext-for-webui.xml"/>
 
@@ -81,6 +87,8 @@
             </list>
           </property>
         </component>
+
+        <component-ref name="multipartHandler"/>
 
         <component-ref name="threadContextHandler"/>
 

--- a/nablarch-jaxrs/src/env/dev/resources/env.properties
+++ b/nablarch-jaxrs/src/env/dev/resources/env.properties
@@ -33,6 +33,22 @@ nablarch.codeCache.loadOnStartUp=false
 # (本番ではレスポンスを重視し初期ロードを実施する。開発環境では起動速度を重視し初期ロードはしない。)
 nablarch.stringResourceCache.loadOnStartup=false
 
+# フォーマット定義ファイルの格納ディレクトリ
+# (TODO: PJのファイルパスに変更する)
+nablarch.filePathSetting.basePathSettings.format=file:./src/main/format
+
+# 出力ファイルの出力先ディレクトリ
+# (TODO: PJのファイルパスに変更する)
+nablarch.filePathSetting.basePathSettings.output=file:./work/output
+
+# アップロードファイルの自動クリーニングを行うかどうか
+# (ディスクを逼迫するので本番環境ではtrue。開発環境ではファイルを確認できるようにfalseとする。)
+nablarch.uploadSettings.autoCleaning=false
+
+# アップロードファイル一時ディレクトリ
+# (TODO: PJのファイルパスに変更する)
+nablarch.filePathSetting.basePathSettings.uploadFileTmpDir=file:./work/tmp
+
 # JNDIでDataSourceを取得する際のリソース名
 # 開発環境ではDataSourceを直接使用するためこの値は使用されないが
 # 本番環境で使用するJNDI用コネクションファクトリを構築するために必要になるので削除しないこと。

--- a/nablarch-jaxrs/src/env/dev/resources/handler_dev.xml
+++ b/nablarch-jaxrs/src/env/dev/resources/handler_dev.xml
@@ -35,6 +35,8 @@
           </property>
         </component>
 
+        <component-ref name="multipartHandler"/>
+
         <component-ref name="threadContextHandler"/>
 
         <component class="nablarch.fw.jaxrs.JaxRsAccessLogHandler"/>

--- a/nablarch-jaxrs/src/env/prod/resources/env.properties
+++ b/nablarch-jaxrs/src/env/prod/resources/env.properties
@@ -9,3 +9,19 @@ nablarch.codeCache.loadOnStartUp=true
 # メッセージの初期ロード設定
 # (本番ではレスポンスを重視し初期ロードを実施する。開発環境では起動速度を重視し初期ロードはしない。)
 nablarch.stringResourceCache.loadOnStartup=true
+
+# フォーマット定義ファイルの格納ディレクトリ
+# (TODO: PJのファイルパスに変更する)
+nablarch.filePathSetting.basePathSettings.format=file:/var/nablarch/format
+
+# 出力ファイルの出力先ディレクトリ
+# (TODO: PJのファイルパスに変更する)
+nablarch.filePathSetting.basePathSettings.output=file:/var/nablarch/output
+
+# アップロードファイルの自動クリーニングを行うかどうか
+# (ディスクを逼迫するので本番環境ではtrue。開発環境ではファイルを確認できるようにfalseとする。)
+nablarch.uploadSettings.autoCleaning=true
+
+# アップロードファイル一時ディレクトリ
+# (TODO: PJのファイルパスに変更する)
+nablarch.filePathSetting.basePathSettings.uploadFileTmpDir=file:/var/tmp/upload

--- a/nablarch-jaxrs/src/main/resources/common.properties
+++ b/nablarch-jaxrs/src/main/resources/common.properties
@@ -26,6 +26,9 @@ nablarch.statementFactory.queryTimeout=600
 # トランザクション分離レベル
 nablarch.transactionFactory.isolationLevel=READ_COMMITTED
 
+# アップロード時に許容するContent-Lengthの最大値（バイト数）
+nablarch.uploadSettings.contentLengthLimit=1000000
+
 # SQLファイルのエンコーディング
 nablarch.sqlLoader.fileEncoding=utf-8
 

--- a/nablarch-jaxrs/src/main/resources/rest-component-configuration.xml
+++ b/nablarch-jaxrs/src/main/resources/rest-component-configuration.xml
@@ -35,6 +35,12 @@
   -->
   <import file="nablarch/webui/db-for-webui.xml"/>
 
+  <!-- ファイルパス設置 -->
+  <import file="nablarch/webui/filepath-for-webui.xml" />
+
+  <!-- ファイルアップロード機能設定 -->
+  <import file="nablarch/webui/multipart.xml" />
+
   <!-- スレッドコンテキストハンドラ -->
   <import file="nablarch/webui/threadcontext-for-webui.xml"/>
 
@@ -90,6 +96,8 @@
             </list>
           </property>
         </component>
+
+        <component-ref name="multipartHandler"/>
 
         <component-ref name="threadContextHandler"/>
 


### PR DESCRIPTION
以下の変更に伴い、RESTful ウェブサービスのアーキタイプにマルチパートのサポートを追加しました。

- https://github.com/nablarch/nablarch-jaxrs-adaptor/pull/49
- https://github.com/nablarch/nablarch-jaxrs-adaptor/pull/49

動作すること自体は確認できていますが、標準の設定ファイルのセットを使用するとファイルパスの設定が諸々ついてくることが気になります。  
が、Webの方も使う・使わないに関わらず設定自体は求めてしまうので考え方としては同じになるのかなと思います（途中から増えるように見える、使われない率はWebよりも高いというところが引っかかるところでしょうか）。