### PR TITLE
コンテナ用ブランクプロジェクトのベースイメージであるTomcatを10.1.34にバージョンアップ

### DIFF
--- a/nablarch-container-jaxrs/pom.xml
+++ b/nablarch-container-jaxrs/pom.xml
@@ -49,7 +49,7 @@
      検証時と異なるバージョンが選択された場合、アプリケーションの動作に影響が出る可能性があるので、
      プロジェクトにおける検証が完了した段階で、バージョンを固定するために、イメージをダイジェストで指定することを推奨する。
     -->
-    <jib.from.image>tomcat:10.1.28-jdk17-temurin</jib.from.image>
+    <jib.from.image>tomcat:10.1.34-jdk17-temurin</jib.from.image>
   </properties>
 
   <!--

--- a/nablarch-container-web/pom.xml
+++ b/nablarch-container-web/pom.xml
@@ -55,7 +55,7 @@
      検証時と異なるバージョンが選択された場合、アプリケーションの動作に影響が出る可能性があるので、
      プロジェクトにおける検証が完了した段階で、バージョンを固定するために、イメージをダイジェストで指定することを推奨する。
     -->
-    <jib.from.image>tomcat:10.1.28-jdk17-temurin</jib.from.image>
+    <jib.from.image>tomcat:10.1.34-jdk17-temurin</jib.from.image>
   </properties>
 
   <!--


### PR DESCRIPTION
コンテナ用ブランクプロジェクトで使用しているTomcatのイメージが[Tomcatの脆弱性](https://jvn.jp/vu/JVNVU98102314/)の範囲に入っているので、バージョンアップします。

> Apache Tomcat 10.1.0-M1から10.1.33まで

対象はWeb、RESTfulです。

修正したアーキタイプからブランクプロジェクトを作成し、疎通確認まで実施しました。