### PR TITLE
gsp-dba-maven-pluginをバージョンアップ

### DIFF
--- a/nablarch-archetype-parent/pom.xml
+++ b/nablarch-archetype-parent/pom.xml
@@ -52,7 +52,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <version.plugins.gsp.dba>5.1.0</version.plugins.gsp.dba>
+    <version.plugins.gsp.dba>5.2.0-SNAPSHOT</version.plugins.gsp.dba>
     <version.plugins.compiler>3.13.0</version.plugins.compiler>
     <version.plugins.surefire>3.5.0</version.plugins.surefire>
     <version.plugins.antrun>3.1.0</version.plugins.antrun>


### PR DESCRIPTION
https://github.com/coastland/gsp-dba-maven-plugin/pull/215 の対応の取り込み。

`nablarch-batch-dbless`および`nablarch-container-batch-dbless`以外のアーキタイプからブランクプロジェクトを作成し、gsp-dba-maven-pluginを実行した時にバージョンが`5.2.0-SNAPSHOT`となっていることを確認。