### PR TITLE
GSPプラグインバージョン更新（v5）

### DIFF
--- a/nablarch-archetype-parent/pom.xml
+++ b/nablarch-archetype-parent/pom.xml
@@ -51,7 +51,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <version.plugins.gsp.dba>4.7.0</version.plugins.gsp.dba>
+    <version.plugins.gsp.dba>4.8.0-SNAPSHOT</version.plugins.gsp.dba>
     <version.plugins.compiler>3.2</version.plugins.compiler>
     <version.plugins.surefire>2.22.2</version.plugins.surefire>
     <version.plugins.antrun>1.7</version.plugins.antrun>


### PR DESCRIPTION
https://github.com/coastland/gsp-dba-maven-plugin/pull/219 の変更を反映するため、gsp-dba-maven-pluginのバージョンを更新しました。

各アーキタイプに反映し、ブランクプロジェクト作成、それぞれのプロジェクトで使用されるgsp-dba-maven-pluginのバージョンが更新されていることを確認しています。