### PR TITLE
コンテナ用のウェブおよびRESTfulウェブサービスのgspを扱うProfileに、Java 11用の依存関係が不足していたため追加

### DIFF
--- a/nablarch-container-jaxrs/pom.xml
+++ b/nablarch-container-jaxrs/pom.xml
@@ -160,6 +160,32 @@
                 <version>2.2.220</version>
                 <scope>runtime</scope>
               </dependency>
+              <!-- Java 11 対応 -->
+              <dependency>
+                <groupId>javax.activation</groupId>
+                <artifactId>javax.activation-api</artifactId>
+                <version>1.2.0</version>
+              </dependency>
+              <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>2.3.0</version>
+              </dependency>
+              <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-core</artifactId>
+                <version>2.3.0</version>
+              </dependency>
+              <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-impl</artifactId>
+                <version>2.3.0</version>
+              </dependency>
+              <dependency>
+                <groupId>javax.annotation</groupId>
+                <artifactId>javax.annotation-api</artifactId>
+                <version>1.3.2</version>
+              </dependency>
             </dependencies>
           </plugin>
           <plugin>

--- a/nablarch-container-web/pom.xml
+++ b/nablarch-container-web/pom.xml
@@ -101,6 +101,32 @@
                 <version>2.2.220</version>
                 <scope>runtime</scope>
               </dependency>
+              <!-- Java 11 対応 -->
+              <dependency>
+                <groupId>javax.activation</groupId>
+                <artifactId>javax.activation-api</artifactId>
+                <version>1.2.0</version>
+              </dependency>
+              <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>2.3.0</version>
+              </dependency>
+              <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-core</artifactId>
+                <version>2.3.0</version>
+              </dependency>
+              <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-impl</artifactId>
+                <version>2.3.0</version>
+              </dependency>
+              <dependency>
+                <groupId>javax.annotation</groupId>
+                <artifactId>javax.annotation-api</artifactId>
+                <version>1.3.2</version>
+              </dependency>
             </dependencies>
           </plugin>
         </plugins>


### PR DESCRIPTION
Pull Request 41でコンテナ用アーキタイプを追加した際に、ウェブおよびRESTfulウェブサービスのgsp-dba-maven-pluginを扱うProfileにJava 11用の依存関係が不足していたため、追加。

具体的には以下のProfileに対して実施。

- コンテナ用ウェブ
  - BACKUP Profile
- コンテナ用RESTfulウェブサービス
  - gsp Profile

修正前は各ProfileでJAXBの依存関係が足りずにgsp-dba-maven-pluginが実行できなかったが、問題が解消していることを確認。
