### PR TITLE
OSSRHからCentral Publisher Portalへ移行

### DIFF
--- a/nablarch-archetype-build-parent/pom.xml
+++ b/nablarch-archetype-build-parent/pom.xml
@@ -49,22 +49,13 @@
     <version.plugins.source>3.3.1</version.plugins.source>
     <version.plugins.javadoc>3.10.0</version.plugins.javadoc>
     <version.plugins.gpg>3.2.5</version.plugins.gpg>
+    <version.plugins.central-publishing>0.7.0</version.plugins.central-publishing>
     <version.plugins.archetype>3.2.1</version.plugins.archetype>
   </properties>
 
   <profiles>
     <profile>
-      <id>ossrh</id>
-      <distributionManagement>
-        <repository>
-          <id>nablarch.staging</id>
-          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-        </repository>
-        <snapshotRepository>
-          <id>nablarch.snapshot</id>
-          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-      </distributionManagement>
+      <id>central</id>
       <build>
         <plugins>
           <plugin>
@@ -106,6 +97,15 @@
                 </goals>
               </execution>
             </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>${version.plugins.central-publishing}</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/nablarch-archetype-parent/pom.xml
+++ b/nablarch-archetype-parent/pom.xml
@@ -66,6 +66,7 @@
     <version.plugins.resources>3.3.1</version.plugins.resources>
     <version.plugins.source>3.3.1</version.plugins.source>
     <version.plugins.gpg>3.2.5</version.plugins.gpg>
+    <version.plugins.central-publishing>0.7.0</version.plugins.central-publishing>
     <version.plugins.jacoco>0.8.12</version.plugins.jacoco>
     <version.plugins.build-helper-maven>3.6.0</version.plugins.build-helper-maven>
     <version.plugins.jib>3.4.2</version.plugins.jib>
@@ -434,17 +435,7 @@
 
   <profiles>
     <profile>
-      <id>ossrh</id>
-      <distributionManagement>
-        <repository>
-          <id>nablarch.staging</id>
-          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-        </repository>
-        <snapshotRepository>
-          <id>nablarch.snapshot</id>
-          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-      </distributionManagement>
+      <id>central</id>
       <build>
         <plugins>
           <plugin>
@@ -486,6 +477,15 @@
                 </goals>
               </execution>
             </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>${version.plugins.central-publishing}</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
OSSRHのサービス終了に向けて、Maven Centralへのデプロイ方法をCentral Publisher Portalへ移行する。

主な変更点は以下のとおり。

- Profile名を`ossrh`から`central`に変更
  - 必須の変更ではないが、OSSRHの名称を残しても今後わかりにくくなるだけなので変更する
- 名称変更したProfileの修正
  - `distributionManagement`の削除
    - デプロイ先のidは`ossrh`から`central`となるが、`central`については明示的な定義は不要
    - SNAPSHOTリポジトリは使用していないので削除
  - Central Publishing Mavenプラグインを追加
    - `mvn deploy`コマンドでCentral Publisher Portalにデプロイするプラグイン
    - デプロイ時にのみ使うため、central Profileにのみ追加

一時的に`version`を6u4に変更し、nablarch-archetype-build-parentとnablarch-archetype-parentのみCentral Publisher Potalへデプロイできることを確認。  

```shell
$ mvn clean deploy -DskipTests -P central
```

![image](https://github.com/user-attachments/assets/6e450a3d-d2c1-4cfd-9259-4902fe5d024d)

![image](https://github.com/user-attachments/assets/5d1aa41a-d5d3-476a-bd92-da80fe7e8eb7)
