### PR TITLE
OSSRHからCentral Publisher Portalへ移行（v5）

### DIFF
--- a/nablarch-archetype-build-parent/pom.xml
+++ b/nablarch-archetype-build-parent/pom.xml
@@ -48,22 +48,13 @@
     <version.plugins.source>2.2.1</version.plugins.source>
     <version.plugins.javadoc>2.9.1</version.plugins.javadoc>
     <version.plugins.gpg>1.5</version.plugins.gpg>
+    <version.plugins.central-publishing>0.7.0</version.plugins.central-publishing>
     <version.plugins.archetype>3.2.1</version.plugins.archetype>
   </properties>
 
   <profiles>
     <profile>
-      <id>ossrh</id>
-      <distributionManagement>
-        <repository>
-          <id>nablarch.staging</id>
-          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-        </repository>
-        <snapshotRepository>
-          <id>nablarch.snapshot</id>
-          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-      </distributionManagement>
+      <id>central</id>
       <build>
         <plugins>
           <plugin>
@@ -105,6 +96,15 @@
                 </goals>
               </execution>
             </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>${version.plugins.central-publishing}</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/nablarch-archetype-parent/pom.xml
+++ b/nablarch-archetype-parent/pom.xml
@@ -67,6 +67,7 @@
     <version.plugins.resources>2.7</version.plugins.resources>
     <version.plugins.source>2.4</version.plugins.source>
     <version.plugins.gpg>1.5</version.plugins.gpg>
+    <version.plugins.central-publishing>0.7.0</version.plugins.central-publishing>
     <version.plugins.jacoco>0.8.11</version.plugins.jacoco>
     <version.plugins.build-helper-maven>1.9.1</version.plugins.build-helper-maven>
     <version.plugins.jib>2.1.0</version.plugins.jib>
@@ -446,17 +447,7 @@
 
   <profiles>
     <profile>
-      <id>ossrh</id>
-      <distributionManagement>
-        <repository>
-          <id>nablarch.staging</id>
-          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-        </repository>
-        <snapshotRepository>
-          <id>nablarch.snapshot</id>
-          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-      </distributionManagement>
+      <id>central</id>
       <build>
         <plugins>
           <plugin>
@@ -498,6 +489,15 @@
                 </goals>
               </execution>
             </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>${version.plugins.central-publishing}</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
OSSRHのサービス終了に向けて、Maven Centralへのデプロイ方法をCentral Publisher Portalへ移行する。

主な変更点は以下のとおり。

- Profile名を`ossrh`から`central`に変更
  - 必須の変更ではないが、OSSRHの名称を残しても今後わかりにくくなるだけなので変更する
- 名称変更したProfileの修正
  - `distributionManagement`の削除
    - デプロイ先のidは`ossrh`から`central`となるが、`central`については明示的な定義は不要
    - SNAPSHOTリポジトリは使用していないので削除
  - Central Publishing Mavenプラグインを追加
    - `mvn deploy`コマンドでCentral Publisher Portalにデプロイするプラグイン
    - デプロイ時にのみ使うため、central Profileにのみ追加

一時的に`version`を5u27に変更し、nablarch-archetype-build-parentとnablarch-archetype-parentのみCentral Publisher Potalへデプロイできることを確認。  

```shell
$ mvn clean deploy -DskipTests -P central
```

![image](https://github.com/user-attachments/assets/6eb51bf3-2f0e-459a-9c3e-c58eca047720)

![image](https://github.com/user-attachments/assets/44fda7d7-c365-4b81-8a79-6151350f4a05)
